### PR TITLE
docs: document a standard installable skill path instead of zip-only distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,17 +92,22 @@ Besides the full app, SlideRule also ships a **self-contained Skill package** th
 
 ### How to Use
 
-The ready-to-import Skill archive is included at [`skills/sliderule.zip`](./skills/sliderule.zip).
+The ready-to-import Skill archive is included at [`skills/sliderule.zip`](./skills/sliderule.zip). Unzip it, then drop the resulting `sliderule/` folder into your agent host's skills directory (Trae: Skills · Claude: skill). See [`skills/README.md`](./skills/README.md) for the exact directory layout.
 
 ```bash
-# 1. Drop the skill package into your agent host's skills directory
+# 1. From the repo root, unzip the canonical Skill package.
+unzip skills/sliderule.zip
+
+# 2. Drop the resulting sliderule/ folder into your agent host's skills directory
 #    (Trae: Skills · Claude: skill)
-# 2. Give it a one-sentence idea — it produces the full spec package below
-# 3. For image previews, provide an image endpoint key:
+# 3. Give it a one-sentence idea - it produces the full spec package below
+# 4. For image previews, provide an image endpoint key:
 export IMAGE_API_KEY=sk-...           # or fill image_config.json -> api_key
 # default: gpt-image-2 · 2K · 16:9 · 600s timeout (all configurable)
 
-# Generate or regenerate images yourself at any time, one per module:
+# Generate or regenerate images yourself at any time, one per module.
+# Run these from inside the extracted skill folder:
+cd sliderule
 python scripts/finalize_previews.py           # module images from spec_tree
 python scripts/batch_images.py prompts.txt    # batch generation against your endpoint
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -94,16 +94,21 @@
 
 ### 怎么用
 
-仓库内已经提供可直接导入的技能包: [`skills/sliderule.zip`](./skills/sliderule.zip)。
+仓库内已经提供可直接导入的技能包: [`skills/sliderule.zip`](./skills/sliderule.zip)。解压后,把生成的 `sliderule/` 文件夹放进你的 Agent 宿主 skills 目录(Trae: Skills · Claude: skill)。目录结构见 [`skills/README.md`](./skills/README.md)。
 
 ```bash
-# 1. 把技能包放进你 Agent 宿主的 skills 目录(Trae:技能 · Claude:skill)
-# 2. 给它一句话想法 —— 它会产出下方整套规格包
-# 3. 出图需要生图端点的 key:
+# 1. 在仓库根目录解压权威技能包
+unzip skills/sliderule.zip
+
+# 2. 把生成的 sliderule/ 文件夹放进你 Agent 宿主的 skills 目录(Trae: Skills · Claude: skill)
+# 3. 给它一句话想法 - 它会产出下方整套规格包
+# 4. 出图需要生图端点的 key:
 export IMAGE_API_KEY=sk-...           # 或填进 image_config.json 的 api_key
 # 默认:gpt-image-2 · 2K · 16:9 · 600 秒超时(均可配)
 
-# 随时自己出图 / 重出(按模块,每个需求一张):
+# 随时自己出图 / 重出(按模块,每个需求一张)。
+# 以下命令请在解压出的 skill 文件夹内执行:
+cd sliderule
 python scripts/finalize_previews.py           # 从 spec_tree 按模块出图
 python scripts/batch_images.py prompts.txt    # 批量,直连你的端点
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,26 @@
+# SlideRule Skill Package
+
+This directory stores the packaged Agent Skill artifact and a partial script mirror.
+
+## Layout
+
+- `sliderule.zip` - The canonical, complete, ready-to-import Skill package. It contains `SKILL.md`, `docs/`, `examples/`, and `scripts/`. Install this artifact.
+- `sliderule/` - A partial unpacked mirror containing only validation and fallback `scripts/`. It is not the complete skill and is not ready to install. The zip is canonical.
+
+## Install
+
+The package follows the standard Agent Skills ecosystem format used by `anthropics/skills`. This repo does not expose a repository-root `SKILL.md`, so install from the zip. From the repo root:
+
+```bash
+unzip skills/sliderule.zip
+```
+
+Or from a clean directory containing the archive:
+
+```bash
+unzip sliderule.zip
+```
+
+Then drop the resulting `sliderule/` folder into your agent host's skills directory (Trae: Skills · Claude: skill).
+
+Use case: one sentence in -> a reviewable, deliverable spec package out, with every gate actually run by scripts.


### PR DESCRIPTION
## What

Documents a clear, standard install path for the `sliderule` Skill package, instead of leaving it as a zip-only blob users have to reverse-engineer.

This addresses #5, where a community member pointed at the standard Agent Skills ecosystem (anthropics/skills) and asked why the project only ships a `.zip` and how to actually use it.

## Changes

- `skills/README.md` (new): documents the actual `skills/` directory layout so the importable skill is discoverable.
  - `sliderule.zip` is the canonical, complete package (contains `SKILL.md`, `docs/`, `examples/`, `scripts/`).
  - `sliderule/` on disk is a partial unpacked mirror (validation/fallback `scripts/` only), with the zip noted as canonical.
  - Concrete install path: `unzip skills/sliderule.zip`, then drop the resulting `sliderule/` folder into the agent host's skills directory (Trae: Skills, Claude: skill).
- `README.md` / `README.zh-CN.md`: make the existing "How to Use" block concrete by showing the `unzip` step explicitly and pointing to `skills/README.md` for the layout. Also adds a `cd sliderule` step so the follow-up `python scripts/...` image commands resolve from inside the extracted folder rather than the repo root.

## Why this shape

`SKILL.md` and the full skill tree currently live only inside `skills/sliderule.zip`; there is no repository-root `SKILL.md`. So the documentation describes the real, working install path (unzip then drop in) and does not claim a one-line CLI install that this repo cannot resolve today.

Documentation only. No application code, tests, or runtime behavior changed.

Closes #5
