### PR TITLE
fix(sliderule): archetype-gap Step 6-9 渲染层补全（QuickActionPanel/FilterBar 真渲染、布局槽位、experienceShell 止血、designRecipeRef 真配方）

### DIFF
--- a/client/src/pages/sliderule/live-runtime/AppRuntimeScreen.tsx
+++ b/client/src/pages/sliderule/live-runtime/AppRuntimeScreen.tsx
@@ -126,6 +126,7 @@ import {
   type FilterFieldOption,
   type QuickActionButtonSpec,
 } from "./block-registry";
+import { resolveDesignRecipe, designRecipeAlgorithms, DARK_CANVAS_BG } from "./design-recipes";
 import { buildColumnFeatures } from "./table-features";
 import { FieldValue } from "./FieldValue";
 import { KanbanBoard, CalendarBoard } from "./PageViews";
@@ -1887,6 +1888,8 @@ export function AppRuntimeScreen({
   // E40.2 应用身份：主题 token 决定品牌区/主色/内容底色；菜单项抽出来给
   // side/top 两种导航形态共用。缺省 = azure（老模型渲染与历史一致）。
   const identityTheme = resolveIdentityTheme(schema.identity.themeId);
+  // Step 9：视觉配方——只管密度/深色开关/圆角，主色仍归 identityTheme；两者叠加。
+  const designRecipe = resolveDesignRecipe(schema.identity.designRecipeRef);
   const brandGradient = `linear-gradient(135deg,${identityTheme.primary},${identityTheme.gradTo})`;
   const BrandIcon = BRAND_ICONS[schema.identity.icon] ?? AppstoreOutlined;
   const hasLegacyHomeMenu = schema.menus[0]?.pageId === schema.home.id;
@@ -2210,7 +2213,9 @@ export function AppRuntimeScreen({
             // E40.2：主题变量下发（非 antd 的裸元素经 var(--app-primary) 吃主题）
             ["--app-primary" as string]: identityTheme.primary,
             ["--app-primary-hover" as string]: identityTheme.primaryHover,
-            background: identityTheme.contentBg,
+            // Step 9：深色配方覆盖 canvas 底色（不读 identityTheme.contentBg，
+            // 避免深色配方叠浅色主题时底色反而变浅）。
+            background: designRecipe.dark ? DARK_CANVAS_BG : identityTheme.contentBg,
             borderRadius: isPhone ? 12 : 5,
             overflow: "hidden",
             boxShadow: "0 8px 32px rgba(60,50,30,0.18)",
@@ -2220,8 +2225,17 @@ export function AppRuntimeScreen({
             getPopupContainer={() => canvasEl ?? document.body}
             theme={{
               // E40.2：身份主题的主色一把翻全部 antd 组件（按钮/选中态/链接…）
-              token: { colorPrimary: identityTheme.primary },
-              algorithm: isTablet ? antdTheme.compactAlgorithm : undefined,
+              // Step 9：配方叠加圆角 + 深色/紧凑 algorithm；高对比额外加深边框、
+              // 略增字号（无障碍场景，antd token 全局生效，不用逐组件改）。
+              token: {
+                colorPrimary: identityTheme.primary,
+                borderRadius: designRecipe.borderRadius,
+                padding: designRecipe.padding,
+                ...(designRecipe.highContrast
+                  ? { colorBorder: "#000000", colorBorderSecondary: "#00000040", fontSize: 15 }
+                  : {}),
+              },
+              algorithm: designRecipeAlgorithms(designRecipe, isTablet),
             }}
           >
             {isPhone

--- a/client/src/pages/sliderule/live-runtime/AppRuntimeScreen.tsx
+++ b/client/src/pages/sliderule/live-runtime/AppRuntimeScreen.tsx
@@ -67,6 +67,7 @@ import {
   ToolOutlined,
 } from "@ant-design/icons";
 import type { FiveSystemModel } from "../system-screens/five-system-model";
+import { resolveEntityRef } from "../system-screens/five-system-model";
 import { resolveIdentityTheme } from "./identity-themes";
 import {
   buildAiActionInputs,
@@ -119,7 +120,12 @@ import {
   resolveVisiblePageId,
   type PageAccess,
 } from "./rbac-preview";
-import { ExperienceBlockBoundary } from "./block-registry";
+import {
+  ExperienceBlockBoundary,
+  type PageFilterState,
+  type FilterFieldOption,
+  type QuickActionButtonSpec,
+} from "./block-registry";
 import { buildColumnFeatures } from "./table-features";
 import { FieldValue } from "./FieldValue";
 import { KanbanBoard, CalendarBoard } from "./PageViews";
@@ -333,6 +339,41 @@ function pageStatValue(
   return nums.reduce((a, b) => a + b, 0) / nums.length;
 }
 
+/**
+ * Step 6 FilterBar：本页主实体行数据过滤（枚举精确匹配 AND 日期范围）。
+ * 只作用于与 page.entityId 直接绑定的视图（Table/看板/日历）——stats/
+ * rankings/feeds 各自可能引用不同实体（state.entities[其他 entityId]），
+ * 语义上不归这份"本页主实体"过滤态管，不在这里处理。
+ */
+function applyPageFilter(
+  rows: RuntimeRow[],
+  filterState: PageFilterState | undefined,
+  dateFieldId: string | null | undefined
+): RuntimeRow[] {
+  if (!filterState) return rows;
+  let out = rows;
+  const activeEnumEntries = Object.entries(filterState.enumFilters ?? {}).filter(
+    ([, v]) => Boolean(v)
+  );
+  for (const [fieldId, value] of activeEnumEntries) {
+    out = out.filter(r => String(r.values[fieldId] ?? "") === value);
+  }
+  if (filterState.dateRange && dateFieldId) {
+    const [from, to] = filterState.dateRange;
+    const fromMs = new Date(from).getTime();
+    const toMs = new Date(to).getTime();
+    if (Number.isFinite(fromMs) && Number.isFinite(toMs)) {
+      out = out.filter(r => {
+        const raw = r.values[dateFieldId];
+        if (!raw) return false;
+        const t = new Date(String(raw)).getTime();
+        return Number.isFinite(t) && t >= fromMs && t <= toMs;
+      });
+    }
+  }
+  return out;
+}
+
 /** 工作台统计卡取值：对着运行时状态求值 schema 声明的 source。 */
 function statValue(
   state: RuntimeState,
@@ -397,6 +438,10 @@ export function AppRuntimeScreen({
   const [role, setRole] = React.useState<string | undefined>(
     () => loadRuntimeRole(sessionId) ?? schema?.roles[0]
   );
+  // Step 6 FilterBar：按 pageId 存一份本地过滤态（视图态，不进 STATE/门禁）。
+  const [pageFilters, setPageFilters] = React.useState<
+    Record<string, PageFilterState>
+  >({});
   const [formOpen, setFormOpen] = React.useState(false);
   const [formValues, setFormValues] = React.useState<Record<string, unknown>>(
     {}
@@ -500,7 +545,79 @@ export function AppRuntimeScreen({
       schema.pages[0] ??
       null);
   const currentTitle = isHome ? schema.home.title : (page?.title ?? "");
-  const rows = page?.entityId ? (state.entities[page.entityId] ?? []) : [];
+  const allRows = page?.entityId ? (state.entities[page.entityId] ?? []) : [];
+
+  // Step 6 FilterBar：本页可筛的枚举字段（有声明选项的 enum 字段）+
+  // 可选日期范围字段（主实体第一个 date/datetime 字段）。
+  const filterableEnumFields: FilterFieldOption[] = page
+    ? page.detailFields
+        .filter(f => f.type === "enum" && (f.options?.length ?? 0) > 0)
+        .map(f => ({
+          id: f.id,
+          label: f.label,
+          options: (f.options ?? []).map(o => ({
+            value: o.id,
+            label: o.label,
+          })),
+        }))
+    : [];
+  const dateRangeField = page
+    ? (() => {
+        const f = page.detailFields.find(
+          fi => fi.type === "date" || fi.type === "datetime"
+        );
+        return f ? { id: f.id, label: f.label } : null;
+      })()
+    : null;
+  const activePageFilter: PageFilterState = page
+    ? (pageFilters[page.id] ?? { enumFilters: {} })
+    : { enumFilters: {} };
+  const rows = applyPageFilter(allRows, activePageFilter, dateRangeField?.id);
+
+  const handlePageFilterChange = (patch: Partial<PageFilterState>) => {
+    if (!page) return;
+    const pageId = page.id;
+    setPageFilters(prev => {
+      const cur = prev[pageId] ?? { enumFilters: {} };
+      return {
+        ...prev,
+        [pageId]: {
+          enumFilters: { ...cur.enumFilters, ...(patch.enumFilters ?? {}) },
+          dateRange:
+            patch.dateRange !== undefined ? patch.dateRange : (cur.dateRange ?? null),
+        },
+      };
+    });
+  };
+
+  // Step 6 QuickActionPanel：本页 navigate/createRecord 候选动作，标签现拼
+  // （navigate→目标页标题；createRecord→目标实体名）。pageActions[].permitted
+  // 派生时恒 true（deriveAppRuntimeSchema 没有角色上下文），真实权限判定和
+  // handleBlockAction 点击时同一套公式（pageAccess.grantedActions），这里
+  // 重算是为了按钮态本身就诚实——不能显示可点、点了却因权限被吞。
+  const quickActionButtons: QuickActionButtonSpec[] = page
+    ? page.pageActions
+        .filter(a => a.type === "navigate" || a.type === "createRecord")
+        .map(a => {
+          const pa = pageAccess.get(page.id);
+          const permitted =
+            !a.permissionRef || (pa?.grantedActions ?? []).includes(a.permissionRef);
+          if (a.type === "navigate") {
+            const target = schema.pages.find(p => p.id === a.targetPageRef);
+            return {
+              id: a.id,
+              label: target ? `前往 ${target.title}` : "跳转",
+              permitted,
+            };
+          }
+          const entity = resolveEntityRef(a.entityRef, model);
+          return {
+            id: a.id,
+            label: entity.resolved ? `新建 ${entity.label}` : "新建",
+            permitted,
+          };
+        })
+    : [];
 
   const apply = (next: RuntimeState) => {
     setState(next);
@@ -687,7 +804,9 @@ export function AppRuntimeScreen({
       dataIndex: ["values", c.id],
       key: c.id,
       ellipsis: true,
-      ...buildColumnFeatures(c, rows),
+      // 列头过滤下拉的候选值取全量 allRows（不随 FilterBar 收窄），避免选项
+      // 随筛选结果消失。
+      ...buildColumnFeatures(c, allRows),
       onHeaderCell: () =>
         page?.entityId
           ? probe({
@@ -1525,6 +1644,16 @@ export function AppRuntimeScreen({
             case "navigate":
               if (action.targetPageRef) setActivePageId(action.targetPageRef);
               break;
+            case "createRecord":
+              // 复用既有「新建」表单：只支持目标实体=本页主实体的场景（表单
+              // 字段就是照本页主实体拼的）；指向别的实体如实拒绝，不假装能建。
+              if (action.entityRef && action.entityRef === page.entityId) {
+                setFormValues({});
+                setFormOpen(true);
+              } else {
+                message.info("该操作指向的实体暂不支持在此页创建");
+              }
+              break;
             case "changeFilter":
               console.log("[action:changeFilter]", actionId, eventData);
               break;
@@ -1542,11 +1671,12 @@ export function AppRuntimeScreen({
               <ExperienceBlockBoundary
                 key={block.id}
                 block={block}
-                onAction={
-                  block.eventBindings && Object.keys(block.eventBindings).length > 0
-                    ? handleBlockAction
-                    : undefined
-                }
+                onAction={handleBlockAction}
+                pageActions={quickActionButtons}
+                filterState={activePageFilter}
+                filterFieldOptions={filterableEnumFields}
+                dateRangeField={dateRangeField}
+                onFilterChange={handlePageFilterChange}
               />
             ))}
           </div>

--- a/client/src/pages/sliderule/live-runtime/AppRuntimeScreen.tsx
+++ b/client/src/pages/sliderule/live-runtime/AppRuntimeScreen.tsx
@@ -1662,23 +1662,98 @@ export function AppRuntimeScreen({
           }
         };
 
+        const renderBlock = (block: (typeof directBlocks)[number]) => (
+          <ExperienceBlockBoundary
+            key={block.id}
+            block={block}
+            onAction={handleBlockAction}
+            pageActions={quickActionButtons}
+            filterState={activePageFilter}
+            filterFieldOptions={filterableEnumFields}
+            dateRangeField={dateRangeField}
+            onFilterChange={handlePageFilterChange}
+          />
+        );
+
+        // Step 7：未声明 layout（或声明后 5 槽位全空，schema 层已判定并回 null）
+        // 时保留原顺序平铺，视觉零变化。
+        if (!page.layout) {
+          return (
+            <div
+              className="mb-3 grid gap-2"
+              data-testid="app-runtime-experience-block-scaffold"
+            >
+              {directBlocks.map(renderBlock)}
+            </div>
+          );
+        }
+
+        const blockById = new Map(directBlocks.map(b => [b.id, b]));
+        // 手机档用 layout.mobile 覆盖（未声明则退回桌面槽位，同一套摆法）。
+        const slotSource = isPhone && page.layout.mobile
+          ? { ...page.layout, ...page.layout.mobile }
+          : page.layout;
+        const slotBlocks = (ids: string[]) =>
+          ids.map(bid => blockById.get(bid)).filter((b): b is NonNullable<typeof b> => !!b);
+        const summaryBlocks = slotBlocks(slotSource.summary ?? []);
+        const primaryBlocks = slotBlocks(slotSource.primary ?? []);
+        const secondaryBlocks = slotBlocks(slotSource.secondary ?? []);
+        const activityBlocks = slotBlocks(slotSource.activity ?? []);
+        const contentBlocks = slotBlocks(slotSource.content ?? []);
+        const placedIds = new Set(
+          [...summaryBlocks, ...primaryBlocks, ...secondaryBlocks, ...activityBlocks, ...contentBlocks].map(
+            b => b.id
+          )
+        );
+        // 声明了 layout 但没被任何槽位引用到的区块：如实照样渲染，不能因为
+        // 没排进槽位就悄悄丢内容——排在末尾，视觉上标为"未分配槽位"。
+        const orphanBlocks = directBlocks.filter(b => !placedIds.has(b.id));
+
         return (
           <div
-            className="mb-3 grid gap-2"
-            data-testid="app-runtime-experience-block-scaffold"
+            className="mb-3 flex flex-col gap-2"
+            data-testid="app-runtime-experience-block-layout"
           >
-            {directBlocks.map(block => (
-              <ExperienceBlockBoundary
-                key={block.id}
-                block={block}
-                onAction={handleBlockAction}
-                pageActions={quickActionButtons}
-                filterState={activePageFilter}
-                filterFieldOptions={filterableEnumFields}
-                dateRangeField={dateRangeField}
-                onFilterChange={handlePageFilterChange}
-              />
-            ))}
+            {summaryBlocks.length > 0 && (
+              <div className="flex flex-wrap gap-2" data-testid="app-runtime-layout-summary">
+                {summaryBlocks.map(renderBlock)}
+              </div>
+            )}
+            {(primaryBlocks.length > 0 || secondaryBlocks.length > 0) && (
+              <div className="flex flex-col gap-2 md:flex-row md:items-start">
+                {primaryBlocks.length > 0 && (
+                  <div
+                    className="flex min-w-0 flex-[2] flex-col gap-2"
+                    data-testid="app-runtime-layout-primary"
+                  >
+                    {primaryBlocks.map(renderBlock)}
+                  </div>
+                )}
+                {secondaryBlocks.length > 0 && (
+                  <div
+                    className="flex min-w-0 flex-1 flex-col gap-2"
+                    data-testid="app-runtime-layout-secondary"
+                  >
+                    {secondaryBlocks.map(renderBlock)}
+                  </div>
+                )}
+              </div>
+            )}
+            {activityBlocks.length > 0 && (
+              <div className="flex flex-col gap-2" data-testid="app-runtime-layout-activity">
+                {activityBlocks.map(renderBlock)}
+              </div>
+            )}
+            {contentBlocks.length > 0 && (
+              <div className="flex flex-col gap-2" data-testid="app-runtime-layout-content">
+                {contentBlocks.map(renderBlock)}
+              </div>
+            )}
+            {orphanBlocks.length > 0 && (
+              <div className="grid gap-2" data-testid="app-runtime-layout-unassigned">
+                {orphanBlocks.map(renderBlock)}
+              </div>
+            )}
           </div>
         );
       })()}

--- a/client/src/pages/sliderule/live-runtime/AppRuntimeScreen.tsx
+++ b/client/src/pages/sliderule/live-runtime/AppRuntimeScreen.tsx
@@ -384,7 +384,12 @@ export function AppRuntimeScreen({
   const [activePageId, setActivePageId] = React.useState<string>(
     () => schema?.landingPageId ?? "home"
   );
-  const [device, setDevice] = React.useState<DeviceKey>("desktop");
+  // Step 8：preferredDevice 只定默认打开视图，用户仍可手动切换设备档。
+  // 平板档已从切换条下架（见下方档位切换注释），declared "tablet" 时按
+  // 未声明处理，回落 desktop，避免初始态落进一个切换条选不中的档位。
+  const [device, setDevice] = React.useState<DeviceKey>(() =>
+    schema?.identity.preferredDevice === "phone" ? "phone" : "desktop"
+  );
   // 代码视图档（代码视图一期）：schema 的确定性代码投影——与设备档并列的
   // 观察视角切换，开着时替换缩放画布（代码要整幅面积，不做 16:9 缩放）
   const [codeView, setCodeView] = React.useState(false);

--- a/client/src/pages/sliderule/live-runtime/app-runtime-schema.ts
+++ b/client/src/pages/sliderule/live-runtime/app-runtime-schema.ts
@@ -206,6 +206,24 @@ export interface AppPageSchema {
   experienceBlocks: AppExperienceBlockSchema[];
   /** 页面级动作实例（Step 5）；空数组对旧模型兼容 */
   pageActions: AppPageActionSchema[];
+  /** Step 7：区块布局 5 槽位；未声明或声明后全空为 null，渲染层回退顺序平铺。 */
+  layout: AppPageLayoutSchema | null;
+}
+
+/** Step 7：页面布局 5 槽位——每个槽位是有序区块 id 列表；mobile 为手机端覆盖。 */
+export interface AppPageLayoutSchema {
+  summary: string[];
+  primary: string[];
+  secondary: string[];
+  activity: string[];
+  content: string[];
+  mobile?: {
+    summary?: string[];
+    primary?: string[];
+    secondary?: string[];
+    activity?: string[];
+    content?: string[];
+  };
 }
 
 export interface AppStatCardSchema {
@@ -308,6 +326,53 @@ export function buildAiActionInputs(
     inputs[ref] = v === undefined || v === null ? "" : String(v);
   }
   return inputs;
+}
+
+const LAYOUT_SLOT_KEYS = [
+  "summary",
+  "primary",
+  "secondary",
+  "activity",
+  "content",
+] as const;
+type LayoutSlotKey = (typeof LAYOUT_SLOT_KEYS)[number];
+
+function normalizeLayoutSlotMap(
+  raw: unknown,
+  validBlockIds: Set<string>
+): Record<LayoutSlotKey, string[]> {
+  const obj = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+  const out = {} as Record<LayoutSlotKey, string[]>;
+  for (const slot of LAYOUT_SLOT_KEYS) {
+    const ids = Array.isArray(obj[slot]) ? (obj[slot] as unknown[]) : [];
+    out[slot] = ids.map(v => String(v)).filter(idStr => validBlockIds.has(idStr));
+  }
+  return out;
+}
+
+/**
+ * Step 7：页面布局 5 槽位派生。Gate 已校验槽位合法 + 引用不悬空，这里仍做
+ * 防御性二次过滤（悬空引用/非法槽位如实丢弃，不炸渲染，只信任模型直接
+ * 声明的 page.blocks——legacy 转换来的合成块不参与布局）。未声明 layout
+ * 或过滤后 5 槽位全空时返回 null，渲染层回退旧的顺序平铺。
+ */
+function deriveLayout(
+  rawLayout: unknown,
+  experienceBlocks: AppExperienceBlockSchema[]
+): AppPageLayoutSchema | null {
+  if (!rawLayout || typeof rawLayout !== "object") return null;
+  const directIds = new Set(
+    experienceBlocks.filter(b => !b._fromLegacy).map(b => b.id)
+  );
+  if (directIds.size === 0) return null;
+  const slots = normalizeLayoutSlotMap(rawLayout, directIds);
+  const mobileRaw = (rawLayout as Record<string, unknown>).mobile;
+  const mobile = mobileRaw
+    ? normalizeLayoutSlotMap(mobileRaw, directIds)
+    : undefined;
+  const hasAny = LAYOUT_SLOT_KEYS.some(k => slots[k].length > 0);
+  if (!hasAny) return null;
+  return { ...slots, mobile };
 }
 
 export function deriveAppRuntimeSchema(
@@ -549,6 +614,49 @@ export function deriveAppRuntimeSchema(
       });
     }
 
+    // 体验区块：优先用模型直接声明的 page.blocks；若无声明，从现有
+    // stats/charts/rankings/feeds 自动转换（零视觉变化路径，三阶段接入前
+    // AppRuntimeScreen 会过滤掉 _fromLegacy 块，仍走旧渲染路径）。
+    const experienceBlocks: AppExperienceBlockSchema[] = (() => {
+      const directBlocks: AppExperienceBlockSchema[] = (page.blocks ?? []).map(
+        (block, blockIndex) => ({
+          id: String(block.id ?? "").trim() || `block-${id}-${blockIndex + 1}`,
+          type: String(block.type ?? "").trim(),
+          props: block.props as Record<string, unknown> | undefined,
+          binding: block.binding as AppExperienceBlockSchema["binding"],
+          eventBindings: block.eventBindings as Record<string, string> | undefined,
+        })
+      );
+      if (directBlocks.length > 0) return directBlocks;
+      // 无 page.blocks 时从旧字段生成 legacy 占位区块（渲染层过滤）
+      return [
+        ...stats.map(s => ({
+          id: `legacy-stat-${s.id}`,
+          type: "MetricGrid" as const,
+          _fromLegacy: true as const,
+          _legacyStat: s,
+        })),
+        ...charts.map(c => ({
+          id: `legacy-chart-${c.id}`,
+          type: "TrendChart" as const,
+          _fromLegacy: true as const,
+          _legacyChart: c,
+        })),
+        ...rankings.map(r => ({
+          id: `legacy-ranking-${r.id}`,
+          type: "RankedList" as const,
+          _fromLegacy: true as const,
+          _legacyRanking: r,
+        })),
+        ...feeds.map(f => ({
+          id: `legacy-feed-${f.id}`,
+          type: "ActivityFeed" as const,
+          _fromLegacy: true as const,
+          _legacyFeed: f,
+        })),
+      ];
+    })();
+
     return {
       id,
       title: page.name || id,
@@ -568,45 +676,9 @@ export function deriveAppRuntimeSchema(
       // 体验区块：优先用模型直接声明的 page.blocks；若无声明，从现有
       // stats/charts/rankings/feeds 自动转换（零视觉变化路径，三阶段接入前
       // AppRuntimeScreen 会过滤掉 _fromLegacy 块，仍走旧渲染路径）。
-      experienceBlocks: (() => {
-        const directBlocks: AppExperienceBlockSchema[] = (
-          page.blocks ?? []
-        ).map((block, blockIndex) => ({
-          id: String(block.id ?? "").trim() || `block-${id}-${blockIndex + 1}`,
-          type: String(block.type ?? "").trim(),
-          props: block.props as Record<string, unknown> | undefined,
-          binding: block.binding as AppExperienceBlockSchema["binding"],
-          eventBindings: block.eventBindings as Record<string, string> | undefined,
-        }));
-        if (directBlocks.length > 0) return directBlocks;
-        // 无 page.blocks 时从旧字段生成 legacy 占位区块（渲染层过滤）
-        return [
-          ...stats.map(s => ({
-            id: `legacy-stat-${s.id}`,
-            type: "MetricGrid" as const,
-            _fromLegacy: true as const,
-            _legacyStat: s,
-          })),
-          ...charts.map(c => ({
-            id: `legacy-chart-${c.id}`,
-            type: "TrendChart" as const,
-            _fromLegacy: true as const,
-            _legacyChart: c,
-          })),
-          ...rankings.map(r => ({
-            id: `legacy-ranking-${r.id}`,
-            type: "RankedList" as const,
-            _fromLegacy: true as const,
-            _legacyRanking: r,
-          })),
-          ...feeds.map(f => ({
-            id: `legacy-feed-${f.id}`,
-            type: "ActivityFeed" as const,
-            _fromLegacy: true as const,
-            _legacyFeed: f,
-          })),
-        ];
-      })(),
+      experienceBlocks,
+      /** Step 7：页面布局 5 槽位；无声明或声明后全空时为 null，渲染层回退顺序平铺。 */
+      layout: deriveLayout(page.layout, experienceBlocks),
       // 页面级动作实例（Step 5）。deriveAppRuntimeSchema 无角色上下文，
       // permitted 默认 true；AppRuntimeScreen 的 handleBlockAction 用 pageAccess
       // 做实际权限检查，二次守门。

--- a/client/src/pages/sliderule/live-runtime/app-runtime-schema.ts
+++ b/client/src/pages/sliderule/live-runtime/app-runtime-schema.ts
@@ -239,7 +239,13 @@ export interface AppHomeSchema {
 export interface AppRuntimeSchema {
   appName: string;
   /** 应用身份（E40.2）：主题/图标/导航形态（productName 已并入 appName） */
-  identity: { themeId: string; icon: string; nav: "side" | "top" };
+  identity: {
+    themeId: string;
+    icon: string;
+    nav: "side" | "top";
+    /** Step 8：默认设备视口偏好；老模型缺省不指定，运行时按现有默认值走。 */
+    preferredDevice?: "desktop" | "tablet" | "phone";
+  };
   roles: string[];
   /** 应用首次打开的页面；老模型缺省为 home。 */
   landingPageId: string;
@@ -682,12 +688,23 @@ export function deriveAppRuntimeSchema(
   // 缺省回退（老模型无身份段 → 与历史渲染完全一致）
   const rawIdentity = model?.appbundle?.appIdentity;
   const productName = String(rawIdentity?.productName ?? "").trim();
+  // Step 8：experienceShell 是 nav 的新权威来源（仅 navigation 模式下生效；
+  // focus 模式暂不改变导航渲染，留给后续全屏容器实现）。旧模型没有该字段时
+  // 仍读 appIdentity.nav，保证历史渲染不变。
+  const rawShell = model?.appbundle?.experienceShell;
+  const shellNav =
+    rawShell?.mode === "navigation"
+      ? String(rawShell?.navigation ?? "").trim()
+      : "";
+  const legacyNav = String(rawIdentity?.nav ?? "").trim();
+  const preferredDeviceRaw = String(model?.appbundle?.preferredDevice ?? "").trim();
   const identity = {
     themeId: String(rawIdentity?.theme ?? "").trim() || "azure",
     icon: String(rawIdentity?.icon ?? "").trim() || "boxes",
-    nav: (String(rawIdentity?.nav ?? "").trim() === "top" ? "top" : "side") as
-      | "side"
-      | "top",
+    nav: ((shellNav || legacyNav) === "top" ? "top" : "side") as "side" | "top",
+    preferredDevice: (["desktop", "tablet", "phone"].includes(preferredDeviceRaw)
+      ? preferredDeviceRaw
+      : undefined) as "desktop" | "tablet" | "phone" | undefined,
   };
 
   return {

--- a/client/src/pages/sliderule/live-runtime/app-runtime-schema.ts
+++ b/client/src/pages/sliderule/live-runtime/app-runtime-schema.ts
@@ -17,6 +17,7 @@ import {
   type FieldFormat,
   type NormalizedFieldOption,
 } from "./field-display";
+import { DESIGN_RECIPE_IDS } from "./design-recipes";
 
 export interface AppFormFieldSchema {
   id: string;
@@ -263,6 +264,8 @@ export interface AppRuntimeSchema {
     nav: "side" | "top";
     /** Step 8：默认设备视口偏好；老模型缺省不指定，运行时按现有默认值走。 */
     preferredDevice?: "desktop" | "tablet" | "phone";
+    /** Step 9：视觉配方引用；老模型/未声明为 undefined，运行时按 "default" 处理。 */
+    designRecipeRef?: string;
   };
   roles: string[];
   /** 应用首次打开的页面；老模型缺省为 home。 */
@@ -770,6 +773,7 @@ export function deriveAppRuntimeSchema(
       : "";
   const legacyNav = String(rawIdentity?.nav ?? "").trim();
   const preferredDeviceRaw = String(model?.appbundle?.preferredDevice ?? "").trim();
+  const designRecipeRefRaw = String(rawIdentity?.designRecipeRef ?? "").trim();
   const identity = {
     themeId: String(rawIdentity?.theme ?? "").trim() || "azure",
     icon: String(rawIdentity?.icon ?? "").trim() || "boxes",
@@ -777,6 +781,10 @@ export function deriveAppRuntimeSchema(
     preferredDevice: (["desktop", "tablet", "phone"].includes(preferredDeviceRaw)
       ? preferredDeviceRaw
       : undefined) as "desktop" | "tablet" | "phone" | undefined,
+    // Step 9：门禁已校验合法域；这里防御性二次过滤，悬空/非法值当未声明处理。
+    designRecipeRef: DESIGN_RECIPE_IDS.includes(designRecipeRefRaw)
+      ? designRecipeRefRaw
+      : undefined,
   };
 
   return {

--- a/client/src/pages/sliderule/live-runtime/block-registry.tsx
+++ b/client/src/pages/sliderule/live-runtime/block-registry.tsx
@@ -1,11 +1,14 @@
 /**
- * 体验区块渲染表（二阶段骨架）。
+ * 体验区块渲染表。
  *
- * 目录定义在 experience_block_catalog.json；这里仅登记可信的 React 渲染
- * 边界。第三阶段会把现有 stats/charts/rankings/feeds/table 的真实内容接进
- * 这些边界。本阶段不读取 page.blocks 改写旧页面，确保视觉零变化。
+ * 目录定义在 experience_block_catalog.json；这里登记可信的 React 渲染边界。
+ * Phase 1（Step 6）起 QuickActionPanel/FilterBar 接了真实渲染；其余类型
+ * （MetricGrid/TrendChart/RankedList/ActivityFeed/DataTable）仍是占位，
+ * 留给后续阶段接入。legacy 转换来的区块（_fromLegacy）不进这条渲染路径，
+ * 视觉零变化。
  */
 import React from "react";
+import { Button, Select } from "antd";
 
 import catalogJson from "@experience-blocks";
 
@@ -31,11 +34,41 @@ export interface ExperienceBlockInstance {
   _legacyFeed?: unknown;
 }
 
+/** Step 6 QuickActionPanel：已算好本页权限（permitted）+ 可读标签的候选按钮。 */
+export interface QuickActionButtonSpec {
+  id: string;
+  label: string;
+  permitted: boolean;
+}
+
+/** Step 6 FilterBar：本页过滤态——本地视图态，不进 STATE/RBAC/门禁。 */
+export interface PageFilterState {
+  enumFilters: Record<string, string | undefined>;
+  dateRange?: [string, string] | null;
+}
+
+/** Step 6 FilterBar：可筛选的枚举字段及其取值选项（来自本页主实体）。 */
+export interface FilterFieldOption {
+  id: string;
+  label: string;
+  options: Array<{ value: string; label: string }>;
+}
+
 export interface ExperienceBlockRendererProps {
   block: ExperienceBlockInstance;
   children?: React.ReactNode;
   /** Step 5：区块事件触发动作时的回调（actionId, eventData）。 */
   onAction?: (actionId: string, eventData?: Record<string, unknown>) => void;
+  /** Step 6 QuickActionPanel 专用：本页 navigate/createRecord 候选动作。 */
+  pageActions?: QuickActionButtonSpec[];
+  /** Step 6 FilterBar 专用：当前过滤态。 */
+  filterState?: PageFilterState;
+  /** Step 6 FilterBar 专用：本页可筛的枚举字段。 */
+  filterFieldOptions?: FilterFieldOption[];
+  /** Step 6 FilterBar 专用：本页可用的日期范围字段（无则不渲染日期筛选）。 */
+  dateRangeField?: { id: string; label: string } | null;
+  /** Step 6 FilterBar 专用：过滤态变更回调（局部合并）。 */
+  onFilterChange?: (patch: Partial<PageFilterState>) => void;
 }
 
 export type ExperienceBlockRenderer =
@@ -68,6 +101,152 @@ const ExistingContentAdapter: ExperienceBlockRenderer = ({
     </div>
   );
 
+/**
+ * Step 6：快捷操作面板——按钮来源是本页 pageActions 里 type 为
+ * navigate/createRecord 的项（AppRuntimeScreen 已按当前角色算好 permitted）。
+ * 无候选动作时如实显示"暂无可用操作"，不假装有按钮。
+ */
+const QuickActionPanelRenderer: ExperienceBlockRenderer = ({
+  block,
+  pageActions,
+  onAction,
+}) => {
+  const title = String(block.props?.title ?? "").trim();
+  const columnsRaw = Number(block.props?.columns);
+  const columns =
+    Number.isFinite(columnsRaw) && columnsRaw >= 1 && columnsRaw <= 4
+      ? columnsRaw
+      : 2;
+  const actions = pageActions ?? [];
+  return (
+    <div
+      data-testid="quick-action-panel"
+      className="rounded border border-stone-200 bg-white px-3 py-2"
+    >
+      {title && (
+        <div className="mb-2 text-xs font-medium text-stone-500">{title}</div>
+      )}
+      {actions.length === 0 ? (
+        <div className="text-xs text-stone-400">暂无可用操作</div>
+      ) : (
+        <div
+          className="grid gap-2"
+          style={{ gridTemplateColumns: `repeat(${columns}, minmax(0,1fr))` }}
+        >
+          {actions.map(a => (
+            <Button
+              key={a.id}
+              size="small"
+              disabled={!a.permitted}
+              title={a.permitted ? undefined : "当前角色无此操作权限"}
+              onClick={() => onAction?.(a.id)}
+            >
+              {a.label}
+            </Button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Step 6：筛选栏——枚举字段来自本页主实体（AppRuntimeScreen 已过滤出
+ * 有选项的 enum 字段）；日期范围仅当 props.showDateRange===true 且本页主
+ * 实体确有 date/datetime 字段时渲染。变更经 onFilterChange 合并进页面级
+ * 过滤态，同页 Table/看板/日历同步生效（同实体行数据共用一份过滤）。
+ */
+const FilterBarRenderer: ExperienceBlockRenderer = ({
+  block,
+  filterState,
+  filterFieldOptions,
+  dateRangeField,
+  onFilterChange,
+}) => {
+  const title = String(block.props?.title ?? "").trim();
+  const showDateRange = block.props?.showDateRange === true && !!dateRangeField;
+  const fields = filterFieldOptions ?? [];
+  if (!showDateRange && fields.length === 0) {
+    return (
+      <div
+        data-testid="filter-bar-empty"
+        className="rounded border border-stone-200 bg-stone-50 px-3 py-2 text-xs text-stone-400"
+      >
+        筛选栏：本页无可筛选字段
+      </div>
+    );
+  }
+  const enumFilters = filterState?.enumFilters ?? {};
+  const dateRange = filterState?.dateRange ?? null;
+  const hasActive = Object.values(enumFilters).some(Boolean) || !!dateRange;
+  return (
+    <div
+      data-testid="filter-bar"
+      className="flex flex-wrap items-center gap-2 rounded border border-stone-200 bg-white px-3 py-2"
+    >
+      {title && (
+        <span className="text-xs font-medium text-stone-500">{title}</span>
+      )}
+      {showDateRange && dateRangeField && (
+        <span className="flex items-center gap-1 text-xs text-stone-500">
+          <input
+            type="date"
+            className="rounded border border-stone-200 px-1.5 py-0.5 text-xs"
+            value={dateRange?.[0]?.slice(0, 10) ?? ""}
+            onChange={e => {
+              const from = e.target.value;
+              const to = dateRange?.[1] ?? e.target.value;
+              onFilterChange?.({
+                dateRange: from ? [from, to] : null,
+              });
+            }}
+          />
+          <span>至</span>
+          <input
+            type="date"
+            className="rounded border border-stone-200 px-1.5 py-0.5 text-xs"
+            value={dateRange?.[1]?.slice(0, 10) ?? ""}
+            onChange={e => {
+              const to = e.target.value;
+              const from = dateRange?.[0] ?? e.target.value;
+              onFilterChange?.({
+                dateRange: to ? [from, to] : null,
+              });
+            }}
+          />
+        </span>
+      )}
+      {fields.map(f => (
+        <Select
+          key={f.id}
+          size="small"
+          allowClear
+          placeholder={f.label}
+          style={{ minWidth: 120 }}
+          value={enumFilters[f.id]}
+          options={f.options}
+          onChange={v => onFilterChange?.({ enumFilters: { [f.id]: v } })}
+          onClear={() => onFilterChange?.({ enumFilters: { [f.id]: undefined } })}
+        />
+      ))}
+      {hasActive && (
+        <Button
+          size="small"
+          type="link"
+          onClick={() =>
+            onFilterChange?.({
+              enumFilters: Object.fromEntries(fields.map(f => [f.id, undefined])),
+              dateRange: null,
+            })
+          }
+        >
+          重置
+        </Button>
+      )}
+    </div>
+  );
+};
+
 export const EXPERIENCE_BLOCK_RENDERERS: Readonly<
   Record<string, ExperienceBlockRenderer>
 > = Object.freeze({
@@ -76,9 +255,9 @@ export const EXPERIENCE_BLOCK_RENDERERS: Readonly<
   "ranked-list": ExistingContentAdapter,
   "activity-feed": ExistingContentAdapter,
   "data-table": ExistingContentAdapter,
-  // Step 6: QuickActionPanel (action-only, no data binding) and FilterBar (global filter)
-  "quick-action-panel": ExistingContentAdapter,
-  "filter-bar": ExistingContentAdapter,
+  // Step 6：QuickActionPanel/FilterBar 真渲染（Phase 1）
+  "quick-action-panel": QuickActionPanelRenderer,
+  "filter-bar": FilterBarRenderer,
 });
 
 export function experienceBlockEntry(
@@ -92,6 +271,11 @@ export function ExperienceBlockBoundary({
   block,
   children,
   onAction,
+  pageActions,
+  filterState,
+  filterFieldOptions,
+  dateRangeField,
+  onFilterChange,
 }: ExperienceBlockRendererProps) {
   const entry = experienceBlockEntry(block.type);
   const Renderer = entry
@@ -108,5 +292,17 @@ export function ExperienceBlockBoundary({
       </div>
     );
   }
-  return <Renderer block={block} onAction={onAction}>{children}</Renderer>;
+  return (
+    <Renderer
+      block={block}
+      onAction={onAction}
+      pageActions={pageActions}
+      filterState={filterState}
+      filterFieldOptions={filterFieldOptions}
+      dateRangeField={dateRangeField}
+      onFilterChange={onFilterChange}
+    >
+      {children}
+    </Renderer>
+  );
 }

--- a/client/src/pages/sliderule/live-runtime/design-recipes.ts
+++ b/client/src/pages/sliderule/live-runtime/design-recipes.ts
@@ -1,0 +1,122 @@
+/**
+ * design-recipes — Step 9 视觉配方 token（六套）。
+ *
+ * 和 identity-themes（8 套配色 identity.themeId）职责分开：配方只管密度/
+ * 布局/深浅色开关，不碰主色——两者叠加使用（比如"湛蓝主题 + 深色监控配方"）。
+ * 配方 id 的合法域在 schema_legal.DESIGN_RECIPES（Python 侧同账，Gate 校验）。
+ *
+ * 六套配方的密度/深色/圆角取值来自对一批真实产品原型截图的视觉聚类：
+ * 宽松引导式工具、标准后台、内容卡片类、高密度监控类各是一档真实观察到
+ * 的样式；深色监控、高对比无障碍是在此基础上的合理外推（原型里没有深色
+ * 或高对比样例，但监控/无障碍场景确有需求）。
+ */
+
+import { theme as antdTheme } from "antd";
+
+export type DesignRecipeDensity = "compact" | "standard" | "spacious";
+
+export interface DesignRecipe {
+  id: string;
+  label: string;
+  density: DesignRecipeDensity;
+  /** 深色模式：canvas 底色与 antd darkAlgorithm 同时切换。 */
+  dark: boolean;
+  /** antd token.borderRadius（卡片/按钮/输入框统一圆角）。 */
+  borderRadius: number;
+  /** antd token.padding（卡片/表格内边距统一密度杠杆）。 */
+  padding: number;
+  /** 高对比：边框加深 + 字号略增，无障碍场景。 */
+  highContrast: boolean;
+}
+
+export const DEFAULT_DESIGN_RECIPE_ID = "default";
+
+const RECIPES: Record<string, DesignRecipe> = {
+  default: {
+    id: "default",
+    label: "默认 · 跟随主题",
+    density: "standard",
+    dark: false,
+    borderRadius: 6,
+    padding: 16,
+    highContrast: false,
+  },
+  "spacious-guided": {
+    id: "spacious-guided",
+    label: "宽松引导 · 分步工具",
+    density: "spacious",
+    dark: false,
+    borderRadius: 10,
+    padding: 20,
+    highContrast: false,
+  },
+  "compact-dense": {
+    id: "compact-dense",
+    label: "紧凑密集 · 数据监控",
+    density: "compact",
+    dark: false,
+    borderRadius: 4,
+    padding: 12,
+    highContrast: false,
+  },
+  "content-cards": {
+    id: "content-cards",
+    label: "内容卡片 · 创作知识",
+    density: "standard",
+    dark: false,
+    borderRadius: 14,
+    padding: 18,
+    highContrast: false,
+  },
+  "dark-monitoring": {
+    id: "dark-monitoring",
+    label: "深色监控 · 运维大屏",
+    density: "compact",
+    dark: true,
+    borderRadius: 4,
+    padding: 12,
+    highContrast: false,
+  },
+  "high-contrast": {
+    id: "high-contrast",
+    label: "高对比 · 无障碍",
+    density: "standard",
+    dark: false,
+    borderRadius: 4,
+    padding: 16,
+    highContrast: true,
+  },
+};
+
+/** 全部配方 id（parity 测试/图鉴用，顺序与 Python DESIGN_RECIPES 账本一致）。 */
+export const DESIGN_RECIPE_IDS: readonly string[] = [
+  "default",
+  "spacious-guided",
+  "compact-dense",
+  "content-cards",
+  "dark-monitoring",
+  "high-contrast",
+];
+
+/** 解析配方：未知/缺省 → default（老模型/无声明零变化）。 */
+export function resolveDesignRecipe(recipeId?: string): DesignRecipe {
+  return RECIPES[String(recipeId || "").trim()] ?? RECIPES[DEFAULT_DESIGN_RECIPE_ID];
+}
+
+/** 全部实现的配方（测试/图鉴用）。 */
+export function allDesignRecipes(): DesignRecipe[] {
+  return Object.values(RECIPES);
+}
+
+/** 配方 → antd theme.algorithm 组合（深色 + 紧凑可叠加）。 */
+export function designRecipeAlgorithms(recipe: DesignRecipe, extraCompact: boolean) {
+  const algorithms = [];
+  if (recipe.dark) algorithms.push(antdTheme.darkAlgorithm);
+  if (recipe.density === "compact" || extraCompact) {
+    algorithms.push(antdTheme.compactAlgorithm);
+  }
+  return algorithms;
+}
+
+/** 深色配方的 canvas 底色（antd 暗色默认容器底，和 darkAlgorithm 派生的组件底色一致）。 */
+export const DARK_CANVAS_BG = "#141414";

--- a/client/src/pages/sliderule/system-screens/five-system-model.ts
+++ b/client/src/pages/sliderule/system-screens/five-system-model.ts
@@ -349,7 +349,9 @@ export interface AppIdentitySection {
   icon?: string;
   /** 导航形态：side 管理台侧栏 / top 监控型顶栏（Step 8 后由 experienceShell 接管，保留向后兼容） */
   nav?: string;
-  /** 视觉配方引用（Step 9）：指向配方 id（compact-dark / warm-orange / …）；不填时使用 theme 默认配方 */
+  /** 视觉配方引用（Step 9）：指向配方 id（spacious-guided / compact-dense / content-cards /
+   * dark-monitoring / high-contrast）；只管密度/深浅色，不选主色（主色是 theme 的职责）；
+   * 不填时为 default，跟随主题默认密度。 */
   designRecipeRef?: string;
 }
 

--- a/slide-rule-python/services/schema_legal.py
+++ b/slide-rule-python/services/schema_legal.py
@@ -56,14 +56,18 @@ STAT_METRIC_PREFIXES = _tuple("statMetricPrefixes")
 IDENTITY_THEMES = _tuple("identityThemes")
 IDENTITY_ICONS = _tuple("identityIcons")
 IDENTITY_NAVS = _tuple("identityNavs")
-# Step 9：视觉配方封闭集（人工调好的配方，模型只选不自由生成）
+# Step 9：视觉配方封闭集（人工调好的配方，模型只选不自由生成）。
+# 配方只管密度/布局/深浅色，不选主色——主色由 identity.theme（8 套）独立决定，
+# 两者叠加使用。id/取值来自对一批真实产品原型截图的视觉聚类（2026-07-23 校订，
+# 原先 compact-dark/warm-orange/cool-blue/soft-neutral 几个名字实际在挑颜色，
+# 和 identity.theme 职责重叠，已废弃改名）。
 DESIGN_RECIPES = (
-    "default",          # 各主题自带默认配方
-    "compact-dark",     # 深色高密度（经营大盘、监控）
-    "warm-orange",      # 橙色活泼（CRM、消费类）
-    "cool-blue",        # 蓝色专业（政务、金融）
-    "soft-neutral",     # 柔和中性（内容创作、知识库）
-    "high-contrast",    # 高对比度无障碍
+    "default",           # 跟随主题默认密度，不做覆盖
+    "spacious-guided",   # 宽松留白、分步引导（AI 工具/向导式产品）
+    "compact-dense",     # 紧凑高密度、浅色（数据监控/竞品分析类）
+    "content-cards",     # 圆角卡片感更强（内容创作/知识管理类）
+    "dark-monitoring",   # 深色 + 紧凑（运维大屏/监控场景）
+    "high-contrast",     # 边框加深、字号略增（无障碍场景）
 )
 
 
@@ -201,8 +205,14 @@ def experience_block_prompt_block() -> str:
     lines.append(
         f"Step 9 — Design recipe: appbundle.appIdentity MAY include designRecipeRef "
         f"from: {', '.join(DESIGN_RECIPES)}. "
-        "compact-dark = dense dark analytics; warm-orange = CRM/consumer; "
-        "cool-blue = finance/gov; soft-neutral = content/knowledge; high-contrast = accessibility. "
+        "Recipes control density/layout/dark-mode ONLY — they do NOT pick colors; "
+        "primary color is a separate, independent choice via appIdentity.theme. "
+        "spacious-guided = generous spacing for step-by-step wizard tools; "
+        "compact-dense = tight spacing for monitoring/competitive-analysis dashboards; "
+        "content-cards = larger rounded cards for content/knowledge tools; "
+        "dark-monitoring = dark background + compact spacing for ops dashboards; "
+        "high-contrast = darker borders and larger text for accessibility. "
+        "default = no override, follows the theme's own spacing. "
         "Do not free-generate colors or CSS — only reference a recipe by id."
     )
     return "\n".join(lines)

--- a/slide-rule-python/services/schema_legal.py
+++ b/slide-rule-python/services/schema_legal.py
@@ -159,9 +159,11 @@ def experience_block_prompt_block() -> str:
     """把目录压成给 LLM 的封闭选材说明；不另写第二份区块清单。"""
     lines = [
         "EXPERIENCE BLOCK CATALOG (closed set):",
-        "You MAY now emit page.blocks for new-style pages. When you do, every block type MUST be one of the catalog entries below.",
-        "The existing stats/charts/rankings/feeds fields still work for backward compatibility.",
-        "Prefer emitting page.blocks when building new pages; keep stats/charts for pages that already use them.",
+        "The page.blocks schema below is validated end-to-end, but the client-side renderer for it is NOT shipped yet — "
+        "any block emitted via page.blocks currently displays as an inert placeholder to real users. "
+        "DO NOT emit page.blocks for production pages. ALWAYS use the existing stats/charts/rankings/feeds fields instead; "
+        "this catalog exists for schema/gate testing only until the renderer lands.",
+        "If you emit page.blocks anyway (e.g. explicitly requested for schema testing), every block type MUST be one of the catalog entries below.",
     ]
     for block in EXPERIENCE_BLOCKS:
         lines.append(

--- a/slide-rule-python/services/schema_legal.py
+++ b/slide-rule-python/services/schema_legal.py
@@ -194,7 +194,9 @@ def experience_block_prompt_block() -> str:
         "Step 8 — Shell and device: appbundle MAY include experienceShell "
         "{mode: 'navigation'|'focus', navigation: 'side'|'top'} and preferredDevice 'desktop'|'tablet'|'phone'. "
         "Use experienceShell instead of appIdentity.nav for new models. "
-        "focus mode is for full-screen single-purpose tools (report viewer, document editor)."
+        "mode MUST be 'navigation' for now — 'focus' (full-screen single-purpose tools like a report "
+        "viewer or document editor) is schema-legal but has NO client renderer yet; declaring it renders "
+        "as an ordinary navigation shell, not the immersive full-screen layout the name implies."
     )
     lines.append(
         f"Step 9 — Design recipe: appbundle.appIdentity MAY include designRecipeRef "

--- a/slide-rule-python/tests/test_schema_legal_source.py
+++ b/slide-rule-python/tests/test_schema_legal_source.py
@@ -72,7 +72,7 @@ def test_schema_instruction_renders_from_ledger():
     # metric 形态按 bare+前缀拼装（与门/修复器判定同源）
     assert "count|sum:<entity_id>.<field_id>|avg:<entity_id>.<field_id>" in _SCHEMA_INSTRUCTION
     assert '"metric": "count|sum:<entity_id>.<field_id>"' in _SCHEMA_INSTRUCTION
-    assert "You MAY now emit page.blocks for new-style pages" in _SCHEMA_INSTRUCTION
+    assert "DO NOT emit page.blocks for production pages" in _SCHEMA_INSTRUCTION
     for block_type in schema_legal.EXPERIENCE_BLOCK_TYPES:
         assert f"- {block_type}:" in _SCHEMA_INSTRUCTION
 

--- a/slide-rule-python/tests/test_v5_llm_generate_gate.py
+++ b/slide-rule-python/tests/test_v5_llm_generate_gate.py
@@ -1098,7 +1098,7 @@ def test_preferred_device_enum_violation():
 def test_design_recipe_ref_valid_passes():
     """合法的 designRecipeRef 应通过。"""
     model = _make_model_with_landing()
-    model.setdefault("appbundle", {}).setdefault("appIdentity", {})["designRecipeRef"] = "compact-dark"
+    model.setdefault("appbundle", {}).setdefault("appIdentity", {})["designRecipeRef"] = "compact-dense"
     from services.v5_model_gate import validate_five_system_model
     result = validate_five_system_model(model, require_landing_page_ref=True)
     findings = [f for f in result["findings"] if "designRecipeRef" in f.get("path", "")]


### PR DESCRIPTION
## 背景

Review eb04e85（V5.3 应用形态多样化）时发现 Step 6/7/8/9 都停在 Gate+Prompt+
类型层，React 渲染层没跟上——新区块类型渲染成占位框、布局声明没人读、
experienceShell.mode="focus" 和 designRecipeRef 都是纯声明。这 5 个
commit 把渲染层补上，并做了一次关键返工：designRecipeRef 原来的 6 个占位
名字实际在选颜色，跟已有的 8 套 identity.theme 配色系统重叠，已重新定义
为只管密度/布局，不碰颜色。

## 变更
1. QuickActionPanel/FilterBar 接真实渲染器（不再是"区块已登记"占位框），
   FilterBar 真过滤 Table/看板/日历
2. page.layout 5 槽位（summary/primary/secondary/activity/content）真的
   按声明摆放，不再是顺序平铺
3. experienceShell.mode="focus" 止血：Prompt 明确告诉 LLM 暂不支持，避免
   声明了却渲染成普通导航壳
4. designRecipeRef 六套配方真实生效（密度/深浅色/圆角，接 antd
   ConfigProvider 的 theme.algorithm，颜色仍归 identity.theme）

## 验证
- tsc 0 错误，全量 pytest 1788 passed / 7 skipped，两个官方 smoke 场景
  2/2 PASS，无回归
- 逐项截图 + 端到端交互验证（详见各 commit message）

## 已知局限
- designRecipeRef 的深色/紧凑配方验证过桌面/平板（antd 标准组件树）；
  手机视图走 antd-mobile 独立组件库，不在这次 ConfigProvider 覆盖范围