### PR TITLE
docs: fix project name in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-SlideRule is in early active development. Security fixes are handled on the main development line unless a maintainer explicitly announces supported release branches.
+WhyBuddy is in early active development. Security fixes are handled on the main development line unless a maintainer explicitly announces supported release branches.
 
 | Version | Supported |
 | ------- | --------- |


### PR DESCRIPTION
## Description
This PR fixes the project name reference in `SECURITY.md`.

## Details
Corrected repository name (`SlideRule` $\to$ `WhyBuddy`).