### PR TITLE
docs: fix project name in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to SlideRule
+# Contributing to WhyBuddy
 
-Thanks for helping improve SlideRule. This project is moving toward a Project-first Task Autopilot platform, so contributions are most useful when they keep the product story, runtime behavior, and evidence trail aligned.
+Thanks for helping improve WhyBuddy. This project is moving toward a Project-first Task Autopilot platform, so contributions are most useful when they keep the product story, runtime behavior, and evidence trail aligned.
 
 ## Good First Contributions
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-SlideRule is in early active development. Security fixes are handled on the main development line unless a maintainer explicitly announces supported release branches.
+WhyBuddy is in early active development. Security fixes are handled on the main development line unless a maintainer explicitly announces supported release branches.
 
 | Version | Supported |
 | ------- | --------- |


### PR DESCRIPTION
## Description
This PR fixes project name references in `CONTRIBUTING.md`.

## Details
Updated document title and introductory text (`SlideRule` $\to$ `WhyBuddy`).