### PR TITLE
docs: fix project name in CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 ## Our Pledge
 
-SlideRule is an open-source project for people building, testing, and discussing AI-assisted work systems. We want the project to be useful, welcoming, and safe for contributors with different backgrounds, skill levels, and viewpoints.
+WhyBuddy is an open-source project for people building, testing, and discussing AI-assisted work systems. We want the project to be useful, welcoming, and safe for contributors with different backgrounds, skill levels, and viewpoints.
 
 Everyone who participates in this project is expected to help keep the community respectful and productive.
 
@@ -33,4 +33,4 @@ When reporting, include as much context as you are comfortable sharing: what hap
 
 Maintainers may remove comments, close discussions, block accounts, or take other reasonable action to protect the project community. Enforcement decisions should be proportionate to the situation and focused on restoring a safe, productive environment.
 
-This code of conduct applies in project spaces, including GitHub issues, pull requests, discussions, documentation, community chat, and public spaces where someone is representing SlideRule.
+This code of conduct applies in project spaces, including GitHub issues, pull requests, discussions, documentation, community chat, and public spaces where someone is representing WhyBuddy.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to SlideRule
+# Contributing to WhyBuddy
 
-Thanks for helping improve SlideRule. This project is moving toward a Project-first Task Autopilot platform, so contributions are most useful when they keep the product story, runtime behavior, and evidence trail aligned.
+Thanks for helping improve WhyBuddy. This project is moving toward a Project-first Task Autopilot platform, so contributions are most useful when they keep the product story, runtime behavior, and evidence trail aligned.
 
 ## Good First Contributions
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-SlideRule is in early active development. Security fixes are handled on the main development line unless a maintainer explicitly announces supported release branches.
+WhyBuddy is in early active development. Security fixes are handled on the main development line unless a maintainer explicitly announces supported release branches.
 
 | Version | Supported |
 | ------- | --------- |


### PR DESCRIPTION
## Description
This PR fixes project name references in `CODE_OF_CONDUCT.md`.

## Details
Updated pledge and enforcement sections (`SlideRule` $\to$ `WhyBuddy`).