### PR TITLE
应用中心接 App Store 数据源（复刻/删除/版本徽标）+ 修 Railway 部署 IPv6 502

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,3 +68,14 @@ SESSION_SECRET=replace_with_a_64_char_random_hex_secret
 # DB_NAME=sliderule
 # DB_USER=root
 # DB_PASSWORD=change_me
+
+# ── 可选：生成应用存储 / App Store（推演出来的应用持久化 → 组建库地基）──
+# 填了连接串就把每个生成的应用（设计层：五系统模型+appbundle+主题+freeform）
+# 存进托管 Postgres，能查询/索引/并发、能列出历史应用/重开/fork/看改版史；
+# 不填就 fail-open 回退本地 JSON 文件（data/sliderule-generated-apps.json），
+# 行为跟"没有 DB"完全一致。抽象层可换：Neon / Supabase / 自建 PG 只改这一行。
+# Neon（serverless Postgres，.env 填连接串即通，自带 pgvector 供后续组建库）：
+#   从 neon.tech → 项目 → Connection string 拷贝，形如：
+# APP_STORE_DATABASE_URL=postgresql://USER:PASSWORD@ep-xxx-pooler.REGION.aws.neon.tech/DB?sslmode=require&channel_binding=require
+# 也接受本地 SQLite（比 JSON 文件强、无需托管服务）：
+# APP_STORE_DATABASE_URL=sqlite:///data/apps.db

--- a/slide-rule-python/Dockerfile
+++ b/slide-rule-python/Dockerfile
@@ -29,4 +29,9 @@ COPY slide-rule-python/ ./
 
 EXPOSE 9700
 
-CMD ["python", "-m", "uvicorn", "app:app", "--host", "0.0.0.0", "--port", "9700"]
+# 绑 :: = IPv4+IPv6 双栈（Railway 等平台的服务间私网是 IPv6-only，只绑 0.0.0.0
+# 会导致 Node 侧走 *.railway.internal 连不进来 → 502；:: 同时兼容 compose 的
+# IPv4 桥接网，两边都能用）。端口听平台注入的 $PORT，没有就回落 9700（compose
+# 里设了 PORT=9700，健康检查照旧命中）。用 sh -c + exec 保证 uvicorn 是 PID 1、
+# 正常接收 SIGTERM 优雅退出。
+CMD ["sh", "-c", "exec python -m uvicorn app:app --host :: --port ${PORT:-9700}"]

--- a/slide-rule-python/config/settings.py
+++ b/slide-rule-python/config/settings.py
@@ -62,6 +62,14 @@ class Settings(BaseSettings):
     RAG_VECTOR_ENABLED: bool = True
     RAG_VECTOR_INDEX_PATH: str = "data/rag-vector-index.json"
 
+    # 生成应用存储 / App Store（推演出来的应用「设计层」持久化 → 组建库地基）。
+    # 填了连接串（任意 SQLAlchemy URL：Neon/自建 Postgres 用 postgresql://…，
+    # 也接受 sqlite:///data/apps.db 这种本地库）就落库；不填 fail-open 回退
+    # 本地 JSON 文件（APP_STORE_FILE），行为与"没有 DB"时完全一致。跟账号功能
+    # 的 MySQL DATABASE_URL（DB_* 那套）是两个独立子系统，互不影响。
+    APP_STORE_DATABASE_URL: Optional[str] = None
+    APP_STORE_FILE: str = "data/sliderule-generated-apps.json"
+
     # AgentLoop worker bridge (108): builds commands for existing Node queue runner.
     # Node remains execution owner; Python owns command construction + receipts.
     # Safe defaults; do not assume node present in dry-run.

--- a/slide-rule-python/requirements.txt
+++ b/slide-rule-python/requirements.txt
@@ -17,6 +17,10 @@ openai>=1.50.0  # for LLM calls in stable style (reference project uses similar)
 # Persistence (sessions, like reference)
 sqlalchemy>=2.0.0
 pymysql>=1.1.0
+# App Store（生成应用持久化 → 组建库地基）：配了 APP_STORE_DATABASE_URL 指向
+# Postgres（Neon/自建）时用 psycopg v3 连（支持 Neon 的 channel_binding）；不配
+# 走本地 JSON 文件兜底，这条依赖也不会被 import。
+psycopg[binary]>=3.2
 
 # P2b execution tools: code.run runs ONLY inside E2B sandbox (fail-closed without key)
 e2b-code-interpreter>=2.8.0

--- a/slide-rule-python/routes/sliderule_full.py
+++ b/slide-rule-python/routes/sliderule_full.py
@@ -1388,3 +1388,65 @@ def get_freeform_preview(pid: str):
     if payload is None:
         return JSONResponse({"error": "not_found"}, status_code=404)
     return JSONResponse(payload)
+
+
+# ---------------------------------------------------------------------------
+# 生成应用存储 / App Store（2026-07-24）——推演出来的应用（设计层）持久化，
+# 后续「组建库」的地基。有 APP_STORE_DATABASE_URL 落托管 Postgres，无则回退
+# 本地 JSON 文件（见 services/app_store.py）。列表/详情/fork/版本/导出。
+# ---------------------------------------------------------------------------
+
+
+@router.get("/apps")
+async def list_generated_apps(
+    limit: int = 50,
+    offset: int = 0,
+    x_internal_key: Optional[str] = Header(None),
+):
+    """应用画廊列表——默认每个应用只出最新版，摘要不含大模型载荷。"""
+    _auth(x_internal_key)
+    from services import app_store
+
+    return {"apps": app_store.list_apps(limit=limit, offset=offset)}
+
+
+@router.get("/apps/{app_id}")
+async def get_generated_app(app_id: str, x_internal_key: Optional[str] = Header(None)):
+    """取一个生成应用的完整记录（含 model_json，可直接重开渲染）。"""
+    _auth(x_internal_key)
+    from services import app_store
+
+    record = app_store.get_app(app_id)
+    if record is None:
+        raise HTTPException(404, "app not found")
+    return record
+
+
+@router.get("/apps/{root_id}/versions")
+async def list_generated_app_versions(root_id: str, x_internal_key: Optional[str] = Header(None)):
+    """一个应用的改版历史（同 root 的所有版本，按 version 升序，摘要）。"""
+    _auth(x_internal_key)
+    from services import app_store
+
+    return {"versions": app_store.list_versions(root_id)}
+
+
+@router.post("/apps/{app_id}/fork")
+async def fork_generated_app(app_id: str, x_internal_key: Optional[str] = Header(None)):
+    """以某个生成应用为起点分出一条新血缘（新 root·v1·parent 指向源）。"""
+    _auth(x_internal_key)
+    from services import app_store
+
+    new_id = app_store.fork_app(app_id)
+    if new_id is None:
+        raise HTTPException(404, "source app not found")
+    return {"id": new_id}
+
+
+@router.get("/apps-export")
+async def export_generated_apps(x_internal_key: Optional[str] = Header(None)):
+    """导出全部应用记录（备份/迁移）——无论后端在哪，手上永远有一份可迁移真数据。"""
+    _auth(x_internal_key)
+    from services import app_store
+
+    return {"apps": app_store.export_all()}

--- a/slide-rule-python/services/app_store.py
+++ b/slide-rule-python/services/app_store.py
@@ -210,6 +210,31 @@ class JsonFileAppStore(AppStoreBackend):
 
 # ────────────────────────── SQLAlchemy 后端（Postgres / SQLite）──────────────
 
+def _sql_engine_config(url: str, null_pool: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+    """按后端方言产出 (connect_args, engine_kwargs)——Postgres 走 Neon 最佳
+    实践，SQLite 走本地默认。抽成纯函数是为了能离线单测这套配置（不真连库）。
+
+    Neon 最佳实践（连接串是 -pooler 端点 = PgBouncer transaction 模式）：
+    - prepare_threshold=None：关掉 psycopg 客户端自动预处理语句。预处理语句活在
+      session 层、跨事务不保留，transaction 池并发下会抛 "prepared statement
+      does not exist"（psycopg#1151 / Crunchy Data / Neon 官方一致建议）。
+    - poolclass=NullPool：用了 Neon 自带 PgBouncer 就别让 SQLAlchemy 再套一层
+      连接池（两层打架 + 长连遇 scale-to-zero 挂起变陈旧）。NullPool 每次开新
+      连接、用完即还给 PgBouncer，是 SQLAlchemy 官方对"外部池"的推荐。
+    - connect_timeout=4：连不上快速失败 → fail-open 回退 JSON。
+    """
+    connect_args: dict[str, Any] = {}
+    engine_kwargs: dict[str, Any] = {"future": True}
+    if url.startswith("postgresql"):
+        connect_args["connect_timeout"] = 4
+        connect_args["prepare_threshold"] = None
+        engine_kwargs["poolclass"] = null_pool
+    else:
+        # 本地 SQLite：无外部池，保留 pre_ping（文件库无 scale-to-zero 问题，无害）。
+        engine_kwargs["pool_pre_ping"] = True
+    return connect_args, engine_kwargs
+
+
 def _sqlalchemy_backend(database_url: str) -> AppStoreBackend:
     """延迟导入 SQLAlchemy——只在真配了连接串时才 import，没配就完全不碰
     这条依赖（保持"无 DB 也能启动"）。"""
@@ -218,6 +243,7 @@ def _sqlalchemy_backend(database_url: str) -> AppStoreBackend:
     )
     from sqlalchemy.dialects.postgresql import JSONB
     from sqlalchemy.orm import Session, declarative_base
+    from sqlalchemy.pool import NullPool
 
     # 生产 Neon/自建 PG 给的是 postgresql://…，SQLAlchemy + psycopg v3 需要
     # postgresql+psycopg:// 前缀；sqlite://… 原样。只补驱动前缀，不动别的。
@@ -269,18 +295,19 @@ def _sqlalchemy_backend(database_url: str) -> AppStoreBackend:
     # 服务挂了）时快速失败 → get_backend 捕获后 fail-open 回退 JSON 文件，绝不
     # 让存储层把主链路吊死（真实撞到：沙盒封了 5432；且 Neon pooler 解析成多个
     # IP，psycopg 会逐个重试，不先探针的话超时叠加到十几秒）。sqlite 跳过探针。
-    connect_args: dict[str, Any] = {}
+    connect_args, engine_kwargs = _sql_engine_config(url, NullPool)
     if url.startswith("postgresql"):
-        connect_args["connect_timeout"] = 4
         from sqlalchemy.engine.url import make_url
 
         parsed = make_url(url)
         if parsed.host:
             import socket
 
-            # 只解析 + 试连第一个 IPv4 地址、硬超时 2s——不用 create_connection
-            # 的多地址轮询（Neon pooler 解析出多个 IP + IPv6，逐个 2s 会叠成十几
-            # 秒；沙盒还不支持 IPv6 family）。探针只验端口可达，握手交给 SQLAlchemy。
+            # 连不上快速失败：只解析 + 试连第一个 IPv4 地址、硬超时 2s——不用
+            # create_connection 的多地址轮询（Neon pooler 解析出多个 IP + IPv6，
+            # 逐个 2s 会叠成十几秒；沙盒还不支持 IPv6 family）。探针只验端口可达，
+            # 真正握手交给 SQLAlchemy。失败 → get_backend 捕获后 fail-open 回退
+            # JSON 文件，绝不让存储层把主链路吊死。sqlite 跳过探针。
             infos = socket.getaddrinfo(parsed.host, parsed.port or 5432, socket.AF_INET, socket.SOCK_STREAM)
             if not infos:
                 raise OSError(f"no IPv4 address for {parsed.host}")
@@ -291,7 +318,7 @@ def _sqlalchemy_backend(database_url: str) -> AppStoreBackend:
                 probe.connect(sa)
             finally:
                 probe.close()
-    engine = create_engine(url, pool_pre_ping=True, future=True, connect_args=connect_args)
+    engine = create_engine(url, connect_args=connect_args, **engine_kwargs)
     Base.metadata.create_all(engine)
 
     class SqlAppStore(AppStoreBackend):

--- a/slide-rule-python/services/app_store.py
+++ b/slide-rule-python/services/app_store.py
@@ -1,0 +1,486 @@
+"""
+生成应用存储 / Generated App Store —— 把推演出来的应用「设计层」持久化，
+作为后续「组建库」的原料仓库。
+
+设计层 = 一个生成应用长啥样：五系统模型 + appbundle + 身份主题 +
+FreeformInsight 内容 + 首页设计。这跟"用户在生成出来的 app 里录入的真实
+业务行数据"（运行时实例层，现在在前端 localStorage）是两回事，本模块只管
+设计层。
+
+后端选择（照 vector_rag / image_client / e2b 同一套"有 key 就用、没 key
+诚实兜底"纪律）：
+- settings.APP_STORE_DATABASE_URL 填了任意 SQLAlchemy URL（Neon/自建
+  Postgres 用 postgresql://…；也接受 sqlite:///data/apps.db 这种本地库）
+  → 落库，可查询、可索引、可并发。
+- 不填 → fail-open 回退本地 JSON 文件（APP_STORE_FILE），行为跟"没有 DB"
+  时完全一致，不引入新的失败面。
+
+两个后端跑同一套 SQLAlchemy/文件无关的接口，model_json 用可移植的 JSON 类型
+（生产落 Postgres 的 JSONB、本地/测试落 SQLite 的 JSON，同一份代码）——所以
+本地用 SQLite 就能把落库逻辑全测通，生产换 Neon 连接串零改动。
+
+血缘：每条记录带 root_id（同一应用的所有版本/派生共享）、parent_id（上一版
+/派生源）、version。save_app 存原始应用（root=自己·v1）；save_version 存同
+一应用的新一版；fork_app 从现有应用分出一条新血缘（新 root·v1·parent 指向源）。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import threading
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from config.settings import settings
+
+
+# ────────────────────────── 记录形状 / 元数据派生 ──────────────────────────
+
+def _new_id() -> str:
+    return uuid.uuid4().hex
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def derive_app_metadata(model: dict[str, Any]) -> dict[str, Any]:
+    """从生成模型里抽出可查询的元数据（列表/筛选/血缘展示用），不塞进
+    model_json 里，避免列表查询要反序列化整个大模型。"""
+    appbundle = model.get("appbundle") or {}
+    identity = appbundle.get("appIdentity") or {}
+    gen_theme = identity.get("generatedTheme") if isinstance(identity.get("generatedTheme"), dict) else {}
+    datamodel = model.get("datamodel") or {}
+    pages = ((model.get("page") or {}).get("pages")) or []
+    return {
+        "product_name": str(identity.get("productName") or "")[:120],
+        "theme_id": str(identity.get("theme") or "")[:64],
+        "theme_label": str((gen_theme or {}).get("label") or "")[:120],
+        "device": str(appbundle.get("preferredDevice") or "")[:16],
+        "landing_page_ref": str(appbundle.get("landingPageRef") or "")[:64],
+        "entity_count": len(datamodel.get("entities") or []),
+        "page_count": len(pages),
+    }
+
+
+def _build_record(
+    model: dict[str, Any],
+    *,
+    goal: str,
+    session_id: Optional[str],
+    gate_passed: bool,
+    app_id: str,
+    root_id: str,
+    parent_id: Optional[str],
+    version: int,
+    dedup_key: Optional[str] = None,
+) -> dict[str, Any]:
+    meta = derive_app_metadata(model)
+    return {
+        "id": app_id,
+        "root_id": root_id,
+        "parent_id": parent_id,
+        "version": version,
+        "session_id": (session_id or "")[:64] or None,
+        "goal": (goal or "")[:2000],
+        "gate_passed": bool(gate_passed),
+        "dedup_key": (dedup_key or None),
+        "created_at": _now_iso(),
+        "model_json": model,
+        **meta,
+    }
+
+
+def model_signature(session_id: Optional[str], model: dict[str, Any]) -> str:
+    """(会话 + 模型内容) 的稳定签名，用作落库幂等键——同一会话反复落同一个
+    模型只更新一条记录，不堆重复；模型真变了（精修改了内容）签名就变、落新记录。"""
+    import hashlib
+
+    payload = json.dumps(model, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    digest = hashlib.sha1(payload).hexdigest()[:16]
+    return f"{(session_id or '-')[:40]}:{digest}"
+
+
+def _summary(record: dict[str, Any]) -> dict[str, Any]:
+    """列表用摘要——去掉 model_json 这个大载荷，只留可查询/展示字段。"""
+    return {k: v for k, v in record.items() if k != "model_json"}
+
+
+# ────────────────────────── 后端接口 ──────────────────────────
+
+class AppStoreBackend:
+    def save(self, record: dict[str, Any]) -> str:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def get(self, app_id: str) -> Optional[dict[str, Any]]:  # pragma: no cover
+        raise NotImplementedError
+
+    def list(self, *, limit: int, offset: int, latest_per_root: bool) -> list[dict[str, Any]]:  # pragma: no cover
+        raise NotImplementedError
+
+    def versions(self, root_id: str) -> list[dict[str, Any]]:  # pragma: no cover
+        raise NotImplementedError
+
+    def find_by_dedup_key(self, dedup_key: str) -> Optional[dict[str, Any]]:  # pragma: no cover
+        raise NotImplementedError
+
+    def export_all(self) -> list[dict[str, Any]]:  # pragma: no cover
+        raise NotImplementedError
+
+
+# ────────────────────────── JSON 文件后端（兜底）──────────────────────────
+
+class JsonFileAppStore(AppStoreBackend):
+    """无 DB 时的兜底：一个 JSON 文件存全部记录（list of record dict）。
+    线程锁 + 临时文件原子写，跟 persistence.py 同套纪律。离线可用。"""
+
+    def __init__(self, store_file: Optional[str] = None) -> None:
+        self._path = Path(store_file or settings.APP_STORE_FILE)
+        self._lock = threading.RLock()
+
+    def _read(self) -> list[dict[str, Any]]:
+        if not self._path.exists():
+            return []
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+        except (ValueError, OSError):
+            return []
+        return data if isinstance(data, list) else []
+
+    def _write(self, rows: list[dict[str, Any]]) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+        tmp.write_text(json.dumps(rows, ensure_ascii=False, indent=2), encoding="utf-8")
+        os.replace(tmp, self._path)
+
+    def save(self, record: dict[str, Any]) -> str:
+        with self._lock:
+            rows = self._read()
+            rows = [r for r in rows if r.get("id") != record["id"]]  # upsert by id
+            rows.append(record)
+            self._write(rows)
+        return record["id"]
+
+    def get(self, app_id: str) -> Optional[dict[str, Any]]:
+        with self._lock:
+            for r in self._read():
+                if r.get("id") == app_id:
+                    return r
+        return None
+
+    def list(self, *, limit: int, offset: int, latest_per_root: bool) -> list[dict[str, Any]]:
+        with self._lock:
+            rows = self._read()
+        rows.sort(key=lambda r: (r.get("created_at") or ""), reverse=True)
+        if latest_per_root:
+            seen: set[str] = set()
+            latest: list[dict[str, Any]] = []
+            # rows 已按时间倒序 → 每个 root 第一次遇到就是最新版
+            for r in rows:
+                root = r.get("root_id") or r.get("id")
+                if root in seen:
+                    continue
+                seen.add(root)
+                latest.append(r)
+            rows = latest
+        return [_summary(r) for r in rows[offset:offset + limit]]
+
+    def versions(self, root_id: str) -> list[dict[str, Any]]:
+        with self._lock:
+            rows = self._read()
+        chain = [r for r in rows if (r.get("root_id") or r.get("id")) == root_id]
+        chain.sort(key=lambda r: r.get("version") or 0)
+        return [_summary(r) for r in chain]
+
+    def find_by_dedup_key(self, dedup_key: str) -> Optional[dict[str, Any]]:
+        with self._lock:
+            for r in self._read():
+                if r.get("dedup_key") == dedup_key:
+                    return r
+        return None
+
+    def export_all(self) -> list[dict[str, Any]]:
+        with self._lock:
+            return self._read()
+
+
+# ────────────────────────── SQLAlchemy 后端（Postgres / SQLite）──────────────
+
+def _sqlalchemy_backend(database_url: str) -> AppStoreBackend:
+    """延迟导入 SQLAlchemy——只在真配了连接串时才 import，没配就完全不碰
+    这条依赖（保持"无 DB 也能启动"）。"""
+    from sqlalchemy import (
+        Boolean, Column, DateTime, Integer, String, Text, create_engine, select, JSON,
+    )
+    from sqlalchemy.dialects.postgresql import JSONB
+    from sqlalchemy.orm import Session, declarative_base
+
+    # 生产 Neon/自建 PG 给的是 postgresql://…，SQLAlchemy + psycopg v3 需要
+    # postgresql+psycopg:// 前缀；sqlite://… 原样。只补驱动前缀，不动别的。
+    url = re.sub(r"^postgresql://", "postgresql+psycopg://", database_url)
+    # 可移植 JSON：Postgres 落 JSONB（可 GIN 索引，组建库拆件用得上），
+    # SQLite 落 JSON（本地/测试同一份代码）。
+    json_type = JSON().with_variant(JSONB, "postgresql")
+
+    # 用经典 Column 声明风格（不是 2.0 的 Mapped[] 注解）——ORM 模型定义在
+    # 函数内（惰性 import：没配 DB 就完全不碰 SQLAlchemy），而 Mapped[] 注解
+    # 解析要求类型名在模块级可见，函数内定义会解析失败。Column 风格不走注解
+    # 解析，功能完全等价。
+    Base = declarative_base()
+
+    class GeneratedApp(Base):
+        __tablename__ = "generated_app"
+        id = Column(String(36), primary_key=True)
+        root_id = Column(String(36), index=True)
+        parent_id = Column(String(36), nullable=True)
+        version = Column(Integer, default=1)
+        session_id = Column(String(64), nullable=True)
+        goal = Column(Text, default="")
+        product_name = Column(String(120), default="", index=True)
+        theme_id = Column(String(64), default="")
+        theme_label = Column(String(120), default="")
+        device = Column(String(16), default="")
+        landing_page_ref = Column(String(64), default="")
+        entity_count = Column(Integer, default=0)
+        page_count = Column(Integer, default=0)
+        gate_passed = Column(Boolean, default=False)
+        dedup_key = Column(String(80), nullable=True, index=True)
+        created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+        model_json = Column(json_type)
+
+        def to_record(self) -> dict[str, Any]:
+            return {
+                "id": self.id, "root_id": self.root_id, "parent_id": self.parent_id,
+                "version": self.version, "session_id": self.session_id, "goal": self.goal,
+                "product_name": self.product_name, "theme_id": self.theme_id,
+                "theme_label": self.theme_label, "device": self.device,
+                "landing_page_ref": self.landing_page_ref, "entity_count": self.entity_count,
+                "page_count": self.page_count, "gate_passed": self.gate_passed,
+                "dedup_key": self.dedup_key,
+                "created_at": self.created_at.isoformat() if self.created_at else None,
+                "model_json": self.model_json,
+            }
+
+    # 连接超时收短 + 先做一次 2s TCP 探针：DB 不可达（网络封端口/连接串错/
+    # 服务挂了）时快速失败 → get_backend 捕获后 fail-open 回退 JSON 文件，绝不
+    # 让存储层把主链路吊死（真实撞到：沙盒封了 5432；且 Neon pooler 解析成多个
+    # IP，psycopg 会逐个重试，不先探针的话超时叠加到十几秒）。sqlite 跳过探针。
+    connect_args: dict[str, Any] = {}
+    if url.startswith("postgresql"):
+        connect_args["connect_timeout"] = 4
+        from sqlalchemy.engine.url import make_url
+
+        parsed = make_url(url)
+        if parsed.host:
+            import socket
+
+            # 只解析 + 试连第一个 IPv4 地址、硬超时 2s——不用 create_connection
+            # 的多地址轮询（Neon pooler 解析出多个 IP + IPv6，逐个 2s 会叠成十几
+            # 秒；沙盒还不支持 IPv6 family）。探针只验端口可达，握手交给 SQLAlchemy。
+            infos = socket.getaddrinfo(parsed.host, parsed.port or 5432, socket.AF_INET, socket.SOCK_STREAM)
+            if not infos:
+                raise OSError(f"no IPv4 address for {parsed.host}")
+            fam, typ, proto, _canon, sa = infos[0]
+            probe = socket.socket(fam, typ, proto)
+            probe.settimeout(2)
+            try:
+                probe.connect(sa)
+            finally:
+                probe.close()
+    engine = create_engine(url, pool_pre_ping=True, future=True, connect_args=connect_args)
+    Base.metadata.create_all(engine)
+
+    class SqlAppStore(AppStoreBackend):
+        def _row_from_record(self, record: dict[str, Any]) -> "GeneratedApp":
+            ca = record.get("created_at")
+            created = datetime.fromisoformat(ca) if isinstance(ca, str) else datetime.now(timezone.utc)
+            return GeneratedApp(
+                id=record["id"], root_id=record["root_id"], parent_id=record.get("parent_id"),
+                version=int(record.get("version") or 1), session_id=record.get("session_id"),
+                goal=record.get("goal") or "", product_name=record.get("product_name") or "",
+                theme_id=record.get("theme_id") or "", theme_label=record.get("theme_label") or "",
+                device=record.get("device") or "", landing_page_ref=record.get("landing_page_ref") or "",
+                entity_count=int(record.get("entity_count") or 0), page_count=int(record.get("page_count") or 0),
+                gate_passed=bool(record.get("gate_passed")), created_at=created,
+                dedup_key=record.get("dedup_key"),
+                model_json=record.get("model_json") or {},
+            )
+
+        def save(self, record: dict[str, Any]) -> str:
+            with Session(engine) as s:
+                existing = s.get(GeneratedApp, record["id"])
+                if existing is not None:
+                    s.delete(existing)
+                    s.flush()
+                s.add(self._row_from_record(record))
+                s.commit()
+            return record["id"]
+
+        def get(self, app_id: str) -> Optional[dict[str, Any]]:
+            with Session(engine) as s:
+                row = s.get(GeneratedApp, app_id)
+                return row.to_record() if row else None
+
+        def list(self, *, limit: int, offset: int, latest_per_root: bool) -> list[dict[str, Any]]:
+            with Session(engine) as s:
+                rows = list(s.scalars(select(GeneratedApp).order_by(GeneratedApp.created_at.desc())))
+            if latest_per_root:
+                seen: set[str] = set()
+                latest: list[GeneratedApp] = []
+                for r in rows:
+                    if r.root_id in seen:
+                        continue
+                    seen.add(r.root_id)
+                    latest.append(r)
+                rows = latest
+            return [_summary(r.to_record()) for r in rows[offset:offset + limit]]
+
+        def versions(self, root_id: str) -> list[dict[str, Any]]:
+            with Session(engine) as s:
+                rows = list(s.scalars(
+                    select(GeneratedApp).where(GeneratedApp.root_id == root_id).order_by(GeneratedApp.version)
+                ))
+            return [_summary(r.to_record()) for r in rows]
+
+        def find_by_dedup_key(self, dedup_key: str) -> Optional[dict[str, Any]]:
+            with Session(engine) as s:
+                row = s.scalars(
+                    select(GeneratedApp).where(GeneratedApp.dedup_key == dedup_key).limit(1)
+                ).first()
+                return row.to_record() if row else None
+
+        def export_all(self) -> list[dict[str, Any]]:
+            with Session(engine) as s:
+                return [r.to_record() for r in s.scalars(select(GeneratedApp))]
+
+    return SqlAppStore()
+
+
+# ────────────────────────── 后端单例选择 ──────────────────────────
+
+_backend_lock = threading.Lock()
+_backend_instance: Optional[AppStoreBackend] = None
+_backend_signature: Optional[str] = None
+# 本进程内已经初始化失败过的 DB URL——不再重试（避免每次 get_backend 都吃一次
+# 连接超时）。直接走 JSON 兜底。reset_backend_cache 会一并清空（测试用）。
+_failed_db_urls: set[str] = set()
+
+
+def _current_signature() -> str:
+    return (settings.APP_STORE_DATABASE_URL or "").strip() or f"jsonfile:{settings.APP_STORE_FILE}"
+
+
+def get_backend() -> AppStoreBackend:
+    """按当前配置返回后端单例。配了 APP_STORE_DATABASE_URL 走 SQLAlchemy，
+    否则走 JSON 文件。签名变了（比如测试里改环境）就重建。DB 初始化失败
+    （连不上/建表失败）时 fail-open 落回 JSON 文件，绝不让存储层拖垮主链路。"""
+    global _backend_instance, _backend_signature
+    with _backend_lock:
+        sig = _current_signature()
+        if _backend_instance is not None and _backend_signature == sig:
+            return _backend_instance
+        db_url = (settings.APP_STORE_DATABASE_URL or "").strip()
+        if db_url and db_url not in _failed_db_urls:
+            try:
+                _backend_instance = _sqlalchemy_backend(db_url)
+            except Exception as exc:  # noqa: BLE001 — 连不上/驱动缺失时诚实降级
+                print(f"[app_store] DB 初始化失败，回退 JSON 文件兜底: {str(exc)[:200]}")
+                _failed_db_urls.add(db_url)  # 本进程不再重试这个 URL
+                _backend_instance = JsonFileAppStore()
+        else:
+            _backend_instance = JsonFileAppStore()
+        _backend_signature = sig
+        return _backend_instance
+
+
+def reset_backend_cache() -> None:
+    """测试用：改了配置后强制下次重建后端（含清空"失败过的 URL"记忆）。"""
+    global _backend_instance, _backend_signature
+    with _backend_lock:
+        _backend_instance = None
+        _backend_signature = None
+        _failed_db_urls.clear()
+
+
+# ────────────────────────── 公开 API ──────────────────────────
+
+def save_app(
+    model: dict[str, Any],
+    *,
+    goal: str = "",
+    session_id: Optional[str] = None,
+    gate_passed: bool = True,
+    dedup_key: Optional[str] = None,
+) -> str:
+    """存一个新生成的原始应用（root=自己·v1·无 parent）。返回 app id。
+
+    传了 dedup_key 且已有同键记录 → 幂等更新那一条（复用它的 id/root/version，
+    刷新 model_json/元数据），不堆重复；用于"同一会话反复落同一个模型"。"""
+    backend = get_backend()
+    if dedup_key:
+        existing = backend.find_by_dedup_key(dedup_key)
+        if existing is not None:
+            record = _build_record(
+                model, goal=goal, session_id=session_id, gate_passed=gate_passed,
+                app_id=existing["id"], root_id=existing["root_id"],
+                parent_id=existing.get("parent_id"), version=existing.get("version") or 1,
+                dedup_key=dedup_key,
+            )
+            record["created_at"] = existing.get("created_at") or record["created_at"]
+            return backend.save(record)
+    app_id = _new_id()
+    record = _build_record(
+        model, goal=goal, session_id=session_id, gate_passed=gate_passed,
+        app_id=app_id, root_id=app_id, parent_id=None, version=1, dedup_key=dedup_key,
+    )
+    return backend.save(record)
+
+
+def save_version(root_id: str, parent_id: str, model: dict[str, Any], *, goal: str = "", session_id: Optional[str] = None, gate_passed: bool = True) -> str:
+    """同一应用的新一版（同 root，version 递增）。用于对已有应用精修/重生成。"""
+    existing = get_backend().versions(root_id)
+    next_version = (max((v.get("version") or 0) for v in existing) + 1) if existing else 1
+    app_id = _new_id()
+    record = _build_record(
+        model, goal=goal, session_id=session_id, gate_passed=gate_passed,
+        app_id=app_id, root_id=root_id, parent_id=parent_id, version=next_version,
+    )
+    return get_backend().save(record)
+
+
+def fork_app(source_id: str, *, session_id: Optional[str] = None) -> Optional[str]:
+    """从现有应用分出一条新血缘：新 root·v1·parent 指向源，model_json 拷贝一份。
+    源不存在返回 None。用于"以某个生成应用为起点，改成一个新应用"。"""
+    source = get_backend().get(source_id)
+    if source is None:
+        return None
+    app_id = _new_id()
+    record = _build_record(
+        source.get("model_json") or {}, goal=source.get("goal") or "",
+        session_id=session_id or source.get("session_id"),
+        gate_passed=bool(source.get("gate_passed")),
+        app_id=app_id, root_id=app_id, parent_id=source_id, version=1,
+    )
+    return get_backend().save(record)
+
+
+def get_app(app_id: str) -> Optional[dict[str, Any]]:
+    return get_backend().get(app_id)
+
+
+def list_apps(*, limit: int = 50, offset: int = 0, latest_per_root: bool = True) -> list[dict[str, Any]]:
+    """列表（默认每个应用只出最新版），返回摘要（不含 model_json）。"""
+    return get_backend().list(limit=max(1, min(limit, 200)), offset=max(0, offset), latest_per_root=latest_per_root)
+
+
+def list_versions(root_id: str) -> list[dict[str, Any]]:
+    return get_backend().versions(root_id)
+
+
+def export_all() -> list[dict[str, Any]]:
+    """导出全部记录（备份/迁移用）——无论后端在哪，手上永远有一份可迁移真数据。"""
+    return get_backend().export_all()

--- a/slide-rule-python/services/v5_capability_executor.py
+++ b/slide-rule-python/services/v5_capability_executor.py
@@ -206,6 +206,7 @@ def _try_llm_generate_evidence(
     llm_json_fn: Optional[Callable[[str], Any]],
     *,
     require_landing_page_ref: bool = True,
+    session_id: Optional[str] = None,
 ) -> Optional[Dict[str, Dict[str, Any]]]:
     """Generate + gate a five-system model for a novel intent.
 
@@ -302,6 +303,19 @@ def _try_llm_generate_evidence(
         model = enrich_monitor_page_overviews(model)
     except Exception as exc:  # noqa: BLE001 — 首页设计是增强项，故障不改变主路径语义
         print(f"[v5_capability_executor] monitor overview enrichment skipped: {str(exc)[:160]}")
+    # 过门 + 增强完的完整设计模型持久化进 App Store（组建库地基）。fail-open：
+    # 存储层任何异常（DB 连不上/建表失败/序列化问题）都不能拖垮闭环发布——
+    # 跟上面几段增强一个纪律。dedup_key = 会话+模型内容签名，同会话反复落同一
+    # 模型只更新一条、不堆重复。
+    try:
+        from . import app_store
+
+        app_store.save_app(
+            model, goal=goal, session_id=session_id, gate_passed=True,
+            dedup_key=app_store.model_signature(session_id, model),
+        )
+    except Exception as exc:  # noqa: BLE001 — 存储是增强项，故障不改变主路径语义
+        print(f"[v5_capability_executor] app store save skipped: {str(exc)[:160]}")
     artifacts = model_to_linkage_artifacts(model, goal)
     return {a["id"].replace("llm-linkage-", ""): a for a in artifacts}
 
@@ -345,6 +359,7 @@ def _build_per_skill_evidence(
         llm_result = _try_llm_generate_evidence(
             goal, llm_json_fn,
             require_landing_page_ref=not _is_override,
+            session_id=getattr(state, "sessionId", None),
         )
         if llm_result is not None:
             for skill in REQUIRED_EVIDENCE_KEYS:
@@ -359,7 +374,9 @@ def _build_per_skill_evidence(
         # T3: novel intent — ask the LLM to generate a five-system model, then run
         # it through the structural gate. Only gate-PASSED models inject evidence;
         # gate failure / LLM unavailable stays fail-closed (0/6). "失败由 gate 拦截而非静默".
-        llm_result = _try_llm_generate_evidence(goal, llm_json_fn)
+        llm_result = _try_llm_generate_evidence(
+            goal, llm_json_fn, session_id=getattr(state, "sessionId", None)
+        )
         if llm_result is not None:
             for skill in REQUIRED_EVIDENCE_KEYS:
                 if skill not in matches:

--- a/slide-rule-python/tests/test_app_store.py
+++ b/slide-rule-python/tests/test_app_store.py
@@ -1,0 +1,136 @@
+"""生成应用存储 / App Store（2026-07-24）的单测覆盖。
+
+同一套 SQLAlchemy 代码在 SQLite（本地/CI，离线）和 Postgres（生产 Neon）上
+跑，所以这里用 SQLite 内存/临时库把落库逻辑全测通，等于间接验证了生产
+Postgres 路径；再单独测 JSON 文件兜底。两条后端跑同一批断言（参数化），
+证明"有 DB 用 DB、没 DB 回退文件"两条路行为一致。
+"""
+
+import os
+import tempfile
+
+import pytest
+
+import services.app_store as store
+
+
+def _model(name: str, entities: int = 2, pages: int = 2, theme: str = "forest") -> dict:
+    return {
+        "datamodel": {"entities": [{"id": f"e{i}", "name": f"E{i}", "fields": []} for i in range(entities)]},
+        "page": {"pages": [{"id": f"p{i}", "kind": "monitor" if i == 0 else "workbench"} for i in range(pages)]},
+        "appbundle": {
+            "landingPageRef": "p0",
+            "preferredDevice": "desktop",
+            "appIdentity": {"productName": name, "theme": theme, "generatedTheme": {"label": f"{theme}·测试"}},
+        },
+    }
+
+
+@pytest.fixture(params=["jsonfile", "sqlite"])
+def configured_store(request, tmp_path, monkeypatch):
+    """同一批断言在两个后端各跑一遍。"""
+    if request.param == "jsonfile":
+        monkeypatch.setattr(store.settings, "APP_STORE_DATABASE_URL", None)
+        monkeypatch.setattr(store.settings, "APP_STORE_FILE", str(tmp_path / "apps.json"))
+    else:
+        monkeypatch.setattr(store.settings, "APP_STORE_DATABASE_URL", f"sqlite:///{tmp_path / 'apps.db'}")
+    store.reset_backend_cache()
+    yield request.param
+    store.reset_backend_cache()
+
+
+def test_save_and_get_roundtrip(configured_store):
+    app_id = store.save_app(_model("咖营通"), goal="咖啡店", session_id="s1", gate_passed=True)
+    rec = store.get_app(app_id)
+    assert rec is not None
+    assert rec["product_name"] == "咖营通"
+    assert rec["theme_id"] == "forest" and rec["theme_label"] == "forest·测试"
+    assert rec["entity_count"] == 2 and rec["page_count"] == 2
+    assert rec["gate_passed"] is True
+    assert rec["model_json"]["appbundle"]["landingPageRef"] == "p0"  # 完整模型回读得到
+
+
+def test_get_missing_returns_none(configured_store):
+    assert store.get_app("does-not-exist") is None
+
+
+def test_list_is_summary_and_latest_per_root(configured_store):
+    a = store.save_app(_model("咖营通"), session_id="s1")
+    store.save_app(_model("宠医云"), session_id="s2")
+    store.save_version(root_id=a, parent_id=a, model=_model("咖营通", entities=3))
+    apps = store.list_apps()
+    assert len(apps) == 2, "每个应用只出最新版"
+    assert all("model_json" not in a for a in apps), "列表是摘要，不含大模型载荷"
+    ka = next(a for a in apps if a["product_name"] == "咖营通")
+    assert ka["version"] == 2 and ka["entity_count"] == 3, "出的应是最新版"
+
+
+def test_versions_chain(configured_store):
+    a = store.save_app(_model("咖营通"))
+    store.save_version(root_id=a, parent_id=a, model=_model("咖营通"))
+    store.save_version(root_id=a, parent_id=a, model=_model("咖营通"))
+    versions = store.list_versions(a)
+    assert [v["version"] for v in versions] == [1, 2, 3]
+    assert all(v["root_id"] == a for v in versions)
+
+
+def test_fork_creates_new_lineage(configured_store):
+    a = store.save_app(_model("咖营通"), session_id="s1")
+    fk = store.fork_app(a, session_id="s9")
+    assert fk is not None and fk != a
+    rec = store.get_app(fk)
+    assert rec["parent_id"] == a, "fork 的 parent 指向源"
+    assert rec["root_id"] == fk and rec["version"] == 1, "fork 是新血缘根、v1"
+    assert rec["model_json"]["appbundle"]["appIdentity"]["productName"] == "咖营通", "model 拷贝了一份"
+    assert len(store.list_apps()) == 2, "fork 后是两个独立根"
+
+
+def test_fork_missing_source_returns_none(configured_store):
+    assert store.fork_app("nope") is None
+
+
+def test_dedup_key_is_idempotent(configured_store):
+    model = _model("咖营通")
+    sig = store.model_signature("s1", model)
+    id1 = store.save_app(model, session_id="s1", dedup_key=sig)
+    id2 = store.save_app(model, session_id="s1", dedup_key=sig)
+    assert id1 == id2, "同 dedup_key → 幂等更新同一条"
+    assert len(store.list_apps()) == 1, "同会话反复落同一模型不堆重复"
+
+
+def test_dedup_key_new_record_when_model_changes(configured_store):
+    id1 = store.save_app(_model("咖营通", entities=2), session_id="s1",
+                         dedup_key=store.model_signature("s1", _model("咖营通", entities=2)))
+    id2 = store.save_app(_model("咖营通", entities=5), session_id="s1",
+                         dedup_key=store.model_signature("s1", _model("咖营通", entities=5)))
+    assert id1 != id2, "模型内容变了 → 签名变 → 落新记录"
+    assert len(store.list_apps()) == 2
+
+
+def test_export_all_returns_full_records(configured_store):
+    store.save_app(_model("咖营通"))
+    store.save_app(_model("宠医云"))
+    dump = store.export_all()
+    assert len(dump) == 2
+    assert all("model_json" in r for r in dump), "导出是完整记录（可迁移备份）"
+
+
+def test_no_db_url_falls_back_to_jsonfile(tmp_path, monkeypatch):
+    """没配连接串时后端就是 JSON 文件——'有 DB 用 DB、没 DB 兜底'。"""
+    monkeypatch.setattr(store.settings, "APP_STORE_DATABASE_URL", None)
+    monkeypatch.setattr(store.settings, "APP_STORE_FILE", str(tmp_path / "apps.json"))
+    store.reset_backend_cache()
+    assert type(store.get_backend()).__name__ == "JsonFileAppStore"
+    store.reset_backend_cache()
+
+
+def test_bad_db_url_fails_open_to_jsonfile(tmp_path, monkeypatch):
+    """DB 初始化失败（无法解析的连接串）时 fail-open 落回 JSON 文件，不崩。"""
+    monkeypatch.setattr(store.settings, "APP_STORE_DATABASE_URL", "not-a-valid-url://xxx")
+    monkeypatch.setattr(store.settings, "APP_STORE_FILE", str(tmp_path / "apps.json"))
+    store.reset_backend_cache()
+    assert type(store.get_backend()).__name__ == "JsonFileAppStore"
+    # 仍能正常存取（走了兜底）
+    app_id = store.save_app(_model("咖营通"))
+    assert store.get_app(app_id) is not None
+    store.reset_backend_cache()

--- a/slide-rule-python/tests/test_app_store.py
+++ b/slide-rule-python/tests/test_app_store.py
@@ -124,6 +124,34 @@ def test_no_db_url_falls_back_to_jsonfile(tmp_path, monkeypatch):
     store.reset_backend_cache()
 
 
+class _FakeNullPool:
+    """占位——只需身份可比对，_sql_engine_config 不实例化它。"""
+
+
+def test_postgres_engine_config_follows_neon_best_practices():
+    """Neon（-pooler = PgBouncer transaction 模式）最佳实践锁死：
+    psycopg 关预处理语句 + NullPool（不双层池）+ 连接超时。"""
+    connect_args, engine_kwargs = store._sql_engine_config(
+        "postgresql+psycopg://u:p@ep-x-pooler.neon.tech/db?sslmode=require", _FakeNullPool
+    )
+    # ① 关掉客户端预处理语句（否则 transaction 池并发抛 prepared statement 错）
+    assert connect_args["prepare_threshold"] is None
+    # ② 用 NullPool，不让 SQLAlchemy 再套一层池跟 PgBouncer 打架
+    assert engine_kwargs["poolclass"] is _FakeNullPool
+    # ③ 连不上快速失败
+    assert connect_args["connect_timeout"] == 4
+    # postgres 不该用 pre_ping（NullPool 无长连可 ping）
+    assert "pool_pre_ping" not in engine_kwargs
+
+
+def test_sqlite_engine_config_no_pgbouncer_tweaks():
+    """SQLite 本地库：不该带 postgres 专属的 NullPool/prepare_threshold。"""
+    connect_args, engine_kwargs = store._sql_engine_config("sqlite:///x.db", _FakeNullPool)
+    assert "prepare_threshold" not in connect_args
+    assert "poolclass" not in engine_kwargs
+    assert engine_kwargs.get("pool_pre_ping") is True
+
+
 def test_bad_db_url_fails_open_to_jsonfile(tmp_path, monkeypatch):
     """DB 初始化失败（无法解析的连接串）时 fail-open 落回 JSON 文件，不崩。"""
     monkeypatch.setattr(store.settings, "APP_STORE_DATABASE_URL", "not-a-valid-url://xxx")


### PR DESCRIPTION
## 概述
两块内容：
1. **应用中心画廊接上 App Store 持久层**（①数据源正位 + ②复刻/删除）；
2. **修 Railway 部署后 Node→Python 私网 IPv6 导致的 502**。

## 主要改动

### 画廊 ①②（应用中心 AppsWorkbench）
- **数据源正位**：从临时会话库切到 App Store 持久层——闭环应用读 `/apps` 摘要、完整模型按卡懒拉走活渲染；尚未落库的在推演会话草稿按 `session_id` 去重合并，**零回退**（现有会话卡一张不丢）。取数分层对标 ToolJet `apps.service`（getAll 摘要 + getApp 详情 + clone + delete）。
- 新增 `app-store-client.ts`：`listApps / getApp / listVersions / forkApp / deleteApp`（走 Node 薄代理 `/api/sliderule/apps*`，catch-all 透传，无需改 Node）。
- 纯函数（可单测）：`buildDetailFromModel`（会话态/App Store 记录同一套指标读法）、`deriveDetailFromAppSummary`、`deriveDetailFromAppRecord`、`mergeGalleryItems`；`filterCards` 泛型化兼容两种条目。
- **复刻**（对标 Budibase `duplicateApp` / Appsmith fork）：卡片菜单「复刻应用」→ `fork_app` 分新血缘 → 重拉画廊；`v>1` 显版本徽标。
- **删除**按源分派：App Store 卡删记录（新增 `DELETE /apps/{id}`，不动对应会话），会话草稿卡删会话。

### 部署修复（Railway / 容器）
- Python 镜像 `CMD` 改绑 IPv6 双栈 `--host ::` + 听 `$PORT`。原 `--host 0.0.0.0` 只绑 IPv4，而 Railway 服务间私网是 **IPv6-only**（`*.railway.internal`），导致 Node 连不进 Python → `/api/sliderule/*` 全 502。`::` 同时兼容 docker-compose 的 IPv4 桥接网，两边都能用。

## 测试
- **前端**：dashboard 21 例绿（含新增 13 例：摘要/记录派生、合并去重、筛选）；`tsc` 0 error。
- **Python**：app_store 26 例绿（含 delete 两后端）。
- **真机 E2E**：Python `:9700` + Vite `:3000` 走真实 `/api/sliderule/apps`——总览 4 个 App Store 应用 + 1 个会话草稿合并渲染；复刻 5→6、删除 6→5（磁盘记录同步递减）；版本徽标 `v2` 正常。

## 风险 / 回退
- App Store 连不上 DB 时 **fail-open 回退 JSON 文件**，不崩。
- 画廊改动为纯前端 + 一个 `DELETE` 端点，Node 代理层零改动。
- Dockerfile 改动对现有 `docker-compose` 完全兼容。