### PR TITLE
应用中心接 App Store 持久层：画廊数据源正位 + 复刻/删除/版本徽标 + 展会三件套 + Render 部署蓝图

### DIFF
--- a/client/src/pages/agent-loop/dashboard/AppsWorkbench.tsx
+++ b/client/src/pages/agent-loop/dashboard/AppsWorkbench.tsx
@@ -297,6 +297,31 @@ export function formatUpdatedAt(iso?: string | null): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
+/**
+ * 相对时间「3 分钟前 / 2 小时前 / 昨天 …」（对标 moment().fromNow()，不引新依赖）。
+ * 画廊看的是"新不新、活跃不活跃"，相对时间比绝对时间戳直观。绝对时间由调用方
+ * 放进 title 悬浮兜底。now 参数注入便于确定性单测。坏输入回空串。
+ */
+export function formatRelativeTime(iso?: string | null, now: number = Date.now()): string {
+  if (!iso) return "";
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return "";
+  const sec = Math.floor((now - t) / 1000);
+  if (sec < 60) return "刚刚";
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min} 分钟前`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr} 小时前`;
+  const day = Math.floor(hr / 24);
+  if (day === 1) return "昨天";
+  if (day < 7) return `${day} 天前`;
+  const week = Math.floor(day / 7);
+  if (week < 5) return `${week} 周前`;
+  const month = Math.floor(day / 30);
+  if (month < 12) return `${month} 个月前`;
+  return `${Math.floor(day / 365)} 年前`;
+}
+
 // ---------------------------------------------------------------------------
 // 组件
 // ---------------------------------------------------------------------------
@@ -359,6 +384,47 @@ function PendingAppThumb({ detail }: { detail: AppCardDetail | null }) {
         )}
       </div>
     </div>
+  );
+}
+
+/**
+ * 骨架卡（对标 ToolJet AppList 的 react-loading-skeleton）：加载时铺等尺寸的
+ * 16:9 灰块占位——结构跟真卡片一致，数据到了直接"填进去"不跳版。用 animate-pulse
+ * 做呼吸微光，不引新依赖。
+ */
+function SkeletonCard() {
+  return (
+    <div className="aspect-video overflow-hidden rounded-xl border border-stone-200 bg-white shadow-sm">
+      <div className="flex h-full w-full animate-pulse flex-col justify-end bg-gradient-to-br from-stone-100 to-stone-50 p-3.5">
+        <div className="flex items-center gap-1.5">
+          <div className="h-5 w-5 shrink-0 rounded-[6px] bg-stone-200" />
+          <div className="h-3 w-2/5 rounded bg-stone-200" />
+        </div>
+        <div className="mt-2 flex items-center gap-2">
+          <div className="h-2.5 w-12 rounded bg-stone-200" />
+          <div className="h-2.5 w-12 rounded bg-stone-200" />
+          <div className="h-2.5 w-10 rounded bg-stone-200" />
+          <div className="ml-auto h-2.5 w-14 rounded bg-stone-200" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** 空态插画（内联 SVG，无外部资产、离线可用、跟随主题）：叠放的卡片 + 一点星光。 */
+function EmptyGalleryArt() {
+  return (
+    <svg width="132" height="104" viewBox="0 0 132 104" fill="none" aria-hidden="true">
+      <rect x="26" y="30" width="80" height="52" rx="8" fill="#eef2ff" />
+      <rect x="34" y="20" width="80" height="52" rx="8" fill="#e0e7ff" />
+      <rect x="42" y="10" width="80" height="52" rx="8" fill="#fff" stroke="#c7d2fe" strokeWidth="2" />
+      <rect x="50" y="20" width="30" height="6" rx="3" fill="#c7d2fe" />
+      <rect x="50" y="32" width="64" height="4" rx="2" fill="#e0e7ff" />
+      <rect x="50" y="42" width="52" height="4" rx="2" fill="#e0e7ff" />
+      <path d="M18 16l2.2 5.3L25.5 23l-5.3 2.2L18 30.5l-2.2-5.3L10.5 23l5.3-1.7L18 16z" fill="#5b6cff" opacity="0.9" />
+      <circle cx="112" cy="86" r="3" fill="#5b6cff" opacity="0.55" />
+      <circle cx="24" cy="72" r="2.5" fill="#5b6cff" opacity="0.4" />
+    </svg>
   );
 }
 
@@ -1048,11 +1114,75 @@ export function AppsWorkbench() {
         (listError ? (
           <div className="mt-8 text-[13px] text-red-500">会话列表拉取失败：{listError}</div>
         ) : items == null ? (
-          <div className="mt-8 text-[13px] text-stone-400">加载中…</div>
-        ) : visible.length === 0 ? (
-          <div className="mt-8 text-[13px] text-stone-400">
-            {paired.length === 0 ? "还没有应用——点右上角「创建新应用」开始推演" : "没有匹配的应用"}
+          // 骨架屏（对标 ToolJet AppList skeleton）：铺等尺寸占位卡，不跳版
+          <div
+            className="mt-5 grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-4"
+            data-testid="apps-skeleton"
+          >
+            {Array.from({ length: 8 }).map((_, i) => (
+              <SkeletonCard key={i} />
+            ))}
           </div>
+        ) : visible.length === 0 ? (
+          paired.length === 0 ? (
+            // 首次空态（对标 ToolJet BlankPage）：插画 + 引导 + 创建 CTA + 官方示例起手卡
+            <div className="mt-10 flex flex-col items-center text-center" data-testid="apps-empty-first">
+              <EmptyGalleryArt />
+              <div className="mt-4 text-[15px] font-semibold text-slate-800">还没有应用</div>
+              <div className="mt-1 text-[13px] text-slate-500">
+                描述你想要的系统，让 AI 推演出你的第一个应用
+              </div>
+              <button
+                data-testid="apps-empty-create"
+                className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-[#5b6cff] px-5 py-2.5 text-[13px] font-semibold text-white shadow-[0_4px_14px_rgba(91,108,255,0.28)] transition hover:bg-[#4a5aef] active:scale-[0.98]"
+                onClick={() => open(newSessionId())}
+              >
+                <span className="text-[15px] leading-none">+</span> 创建新应用
+              </button>
+              {examples.length > 0 && (
+                <div className="mt-8 w-full max-w-lg">
+                  <div className="mb-2.5 text-[12px] text-slate-400">或从官方示例起手</div>
+                  <div className="flex flex-wrap justify-center gap-2">
+                    {examples.slice(0, 4).map(ex => {
+                      const th = resolveIdentityTheme(ex.theme);
+                      return (
+                        <button
+                          key={ex.domain}
+                          data-testid={`empty-starter-${ex.domain}`}
+                          className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-[12.5px] text-slate-700 shadow-sm transition hover:border-[#5b6cff]/50 hover:shadow"
+                          onClick={() => useTemplate(ex)}
+                        >
+                          <span
+                            className="h-2.5 w-2.5 rounded-full"
+                            style={{ background: th.primary }}
+                          />
+                          {ex.productName}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+            </div>
+          ) : (
+            // 搜不到（有应用，但当前搜索/筛选无匹配）
+            <div className="mt-10 flex flex-col items-center text-center" data-testid="apps-empty-search">
+              <EmptyGalleryArt />
+              <div className="mt-4 text-[14px] font-medium text-slate-600">没有匹配的应用</div>
+              <div className="mt-1 text-[12.5px] text-slate-400">换个关键词，或清空筛选看看</div>
+              {(query || filter !== "all") && (
+                <button
+                  className="mt-3 rounded-lg px-3 py-1.5 text-[12.5px] font-medium text-[#5b6cff] transition hover:bg-[#eef2ff]"
+                  onClick={() => {
+                    setQuery("");
+                    setFilter("all");
+                  }}
+                >
+                  清空筛选
+                </button>
+              )}
+            </div>
+          )
         ) : (
           <div className="mt-5 grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-4">
             {pagedMine.map(({ item, detail }) => {
@@ -1065,6 +1195,7 @@ export function AppsWorkbench() {
               const canOpen = Boolean(item.sessionId);
               const isApp = item.source === "app";
               const version = item.version ?? 1;
+              const rel = formatRelativeTime(item.lastActive ?? item.createdAt);
               return (
                 <CenterCard
                   key={item.key}
@@ -1101,6 +1232,14 @@ export function AppsWorkbench() {
                             title="改版次数（App Store 血缘）"
                           >
                             v{version}
+                          </span>
+                        )}
+                        {rel && (
+                          <span
+                            className="inline-flex items-center text-white/65"
+                            title={formatUpdatedAt(item.lastActive ?? item.createdAt)}
+                          >
+                            {rel}
                           </span>
                         )}
                       </>

--- a/client/src/pages/agent-loop/dashboard/AppsWorkbench.tsx
+++ b/client/src/pages/agent-loop/dashboard/AppsWorkbench.tsx
@@ -572,6 +572,9 @@ export function AppsWorkbench() {
   const [query, setQuery] = React.useState("");
   const [sortDesc, setSortDesc] = React.useState(true);
   const [menuFor, setMenuFor] = React.useState<string | null>(null);
+  // 复刻改名弹框（对标 Budibase duplicateApp：预填「源名 副本」让用户改名）
+  const [forkModal, setForkModal] = React.useState<{ item: GalleryItem; name: string } | null>(null);
+  const [forkBusy, setForkBusy] = React.useState(false);
   const [page, setPage] = React.useState(1);
   // E28：订阅会话库更新事件（侧栏删会话/新话题落盘）→ 重拉画廊
   const [reloadKey, setReloadKey] = React.useState(0);
@@ -768,10 +771,26 @@ export function AppsWorkbench() {
    * 以某个 App Store 应用为起点分出一条新血缘（新 root·v1·parent 指向源），
    * 成功后重拉画廊——新卡出现在列表里，用户可点开继续改。后端 fork_app 现成。
    */
-  const forkAppCard = async (gi: GalleryItem) => {
+  /** 点「复刻」→ 开改名弹框，预填「源名 副本」（不再一键复刻出同名孪生卡）。 */
+  const openForkModal = (gi: GalleryItem) => {
     setMenuFor(null);
     if (gi.source !== "app" || !gi.appId) return;
-    const newId = await forkApp(gi.appId);
+    const baseName =
+      details[gi.key]?.identity?.productName ||
+      gi.summary?.product_name ||
+      gi.goal ||
+      "应用";
+    setForkModal({ item: gi, name: `${baseName} 副本` });
+  };
+
+  /** 确认复刻：带新名调 fork_app 分新血缘（不继承源会话），成功后重拉画廊。 */
+  const confirmFork = async () => {
+    const fm = forkModal;
+    if (!fm?.item.appId || forkBusy) return;
+    setForkBusy(true);
+    const newId = await forkApp(fm.item.appId, fm.name);
+    setForkBusy(false);
+    setForkModal(null);
     if (newId) setReloadKey(k => k + 1);
   };
 
@@ -1113,7 +1132,7 @@ export function AppsWorkbench() {
                             <button
                               data-testid={`app-fork-${item.appId}`}
                               className="flex w-full items-center gap-2 px-3 py-1.5 text-[12px] text-slate-600 hover:bg-slate-50"
-                              onClick={() => void forkAppCard(item)}
+                              onClick={() => openForkModal(item)}
                             >
                               <GitBranch size={13} /> 复刻应用
                             </button>
@@ -1206,6 +1225,58 @@ export function AppsWorkbench() {
             onChange={p => setPage(p)}
             showSizeChanger={false}
           />
+        </div>
+      )}
+
+      {/* 复刻改名弹框（对标 Budibase duplicateApp）：预填「源名 副本」，改名后确认。
+          fork 分新血缘、不继承源会话——点开副本不会误进源应用的会话。 */}
+      {forkModal && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          data-testid="fork-modal"
+          onClick={() => !forkBusy && setForkModal(null)}
+        >
+          <div
+            className="w-full max-w-sm rounded-xl bg-white p-5 shadow-xl"
+            onClick={e => e.stopPropagation()}
+          >
+            <div className="flex items-center gap-2 text-[15px] font-semibold text-slate-900">
+              <GitBranch size={16} className="text-[#5b6cff]" /> 复刻应用
+            </div>
+            <div className="mt-1 text-[12px] text-slate-500">
+              复制一份为新应用（记着从谁复刻而来），给它起个名：
+            </div>
+            <input
+              autoFocus
+              data-testid="fork-name-input"
+              value={forkModal.name}
+              disabled={forkBusy}
+              onChange={e => setForkModal(m => (m ? { ...m, name: e.target.value } : m))}
+              onKeyDown={e => {
+                if (e.key === "Enter") void confirmFork();
+                if (e.key === "Escape") setForkModal(null);
+              }}
+              className="mt-3 w-full rounded-lg border border-slate-200 px-3 py-2 text-[13px] text-slate-800 outline-none transition focus:border-[#5b6cff] focus:ring-2 focus:ring-[#5b6cff]/20"
+              placeholder="副本名称"
+            />
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                className="rounded-lg px-3 py-1.5 text-[12.5px] font-medium text-slate-500 transition hover:bg-slate-100"
+                disabled={forkBusy}
+                onClick={() => setForkModal(null)}
+              >
+                取消
+              </button>
+              <button
+                data-testid="fork-confirm"
+                className="inline-flex items-center gap-1.5 rounded-lg bg-[#5b6cff] px-4 py-1.5 text-[12.5px] font-semibold text-white transition hover:bg-[#4a5aef] disabled:opacity-60"
+                disabled={forkBusy || !forkModal.name.trim()}
+                onClick={() => void confirmFork()}
+              >
+                {forkBusy ? "复刻中…" : "复刻"}
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/client/src/pages/agent-loop/dashboard/AppsWorkbench.tsx
+++ b/client/src/pages/agent-loop/dashboard/AppsWorkbench.tsx
@@ -54,6 +54,13 @@ import {
   newSessionId,
   notifySessionsUpdated,
 } from "./SidebarSessions";
+import {
+  listApps,
+  getApp,
+  forkApp,
+  deleteApp,
+  type AppStoreSummary,
+} from "./app-store-client";
 import { IS_GITHUB_PAGES } from "@/lib/deploy-target";
 import {
   GITHUB_PAGES_DEMO_GOAL,
@@ -98,16 +105,14 @@ export interface AppCardDetail {
   model: FiveSystemModel | null;
 }
 
-/** 从持久化会话状态推导卡片详情（不发明数据：模型缺失就是 draft）。 */
-export function deriveAppCardDetail(state: unknown): AppCardDetail {
-  const s = (state ?? {}) as Record<string, any>;
-  const closure = s.publishClosure ?? {};
-  const evidenceCount = Number(closure.evidencePresentCount ?? 0) || 0;
-  const blocked = Boolean(closure.blocked);
-  const model: FiveSystemModel | null = mergeFiveSystemModels(
-    null,
-    parseFiveSystemModelFromPerSkillEvidence(closure.perSkillEvidence)
-  );
+/**
+ * 五系统模型 → 卡片详情的核心（会话态与 App Store 记录共用同一套读法：
+ * 都是从同一份 five-system 模型抽指标，保证两条数据源的卡片指标口径一致）。
+ */
+export function buildDetailFromModel(
+  model: FiveSystemModel | null,
+  opts: { evidenceCount: number; blocked: boolean; awaitReason?: unknown; stableDigest?: string }
+): AppCardDetail {
   const entitiesArr = model?.datamodel?.entities ?? [];
   const pagesArr = model?.page?.pages ?? [];
   const nodesArr = (model?.workflow as any)?.nodes ?? [];
@@ -123,15 +128,15 @@ export function deriveAppCardDetail(state: unknown): AppCardDetail {
         }
       : null;
   const status: AppCardStatus =
-    evidenceCount >= 6 && !blocked && model
+    opts.evidenceCount >= 6 && !opts.blocked && model
       ? "runnable"
-      : s.awaitReason
+      : opts.awaitReason
         ? "awaiting"
         : "draft";
   return {
     status,
-    evidenceCount,
-    blocked,
+    evidenceCount: opts.evidenceCount,
+    blocked: opts.blocked,
     entities: entitiesArr.length,
     pages: pagesArr.length,
     flowNodes: Array.isArray(nodesArr) ? nodesArr.length : 0,
@@ -140,19 +145,139 @@ export function deriveAppCardDetail(state: unknown): AppCardDetail {
     identity,
     pageNames: pagesArr.map((p: any) => String(p?.name ?? p?.id ?? "")).filter(Boolean).slice(0, 6),
     entityNames: entitiesArr.map((e: any) => String(e?.name ?? e?.id ?? "")).filter(Boolean).slice(0, 4),
-    stableDigest: String(closure.stableDigest ?? closure.closureHash ?? "").slice(0, 32) || undefined,
+    stableDigest: opts.stableDigest,
     model,
   };
+}
+
+/** 从持久化会话状态推导卡片详情（不发明数据：模型缺失就是 draft）。 */
+export function deriveAppCardDetail(state: unknown): AppCardDetail {
+  const s = (state ?? {}) as Record<string, any>;
+  const closure = s.publishClosure ?? {};
+  const model: FiveSystemModel | null = mergeFiveSystemModels(
+    null,
+    parseFiveSystemModelFromPerSkillEvidence(closure.perSkillEvidence)
+  );
+  return buildDetailFromModel(model, {
+    evidenceCount: Number(closure.evidencePresentCount ?? 0) || 0,
+    blocked: Boolean(closure.blocked),
+    awaitReason: s.awaitReason,
+    stableDigest: String(closure.stableDigest ?? closure.closureHash ?? "").slice(0, 32) || undefined,
+  });
+}
+
+/**
+ * App Store 完整记录（含 model_json）→ 卡片详情。App Store 只存闭环应用，
+ * model_json 就是那份 five-system 模型，直接喂 buildDetailFromModel（证据满 6、
+ * 不 blocked），得到的指标/身份/活渲染模型跟会话卡完全同源。
+ */
+export function deriveDetailFromAppRecord(modelJson: unknown): AppCardDetail {
+  const model = (modelJson && typeof modelJson === "object"
+    ? (modelJson as FiveSystemModel)
+    : null);
+  return buildDetailFromModel(model, { evidenceCount: 6, blocked: false });
+}
+
+/**
+ * App Store 列表摘要 → 卡片「即时」详情（模型加载前的占位）。摘要不含完整模型，
+ * 所以 model=null、roles/aiCaps 暂 0，进视口懒拉到 model 后由 deriveDetailFromAppRecord
+ * 升级。产品名/主题/页面数/实体数摘要里就有，先渲染出来。
+ */
+export function deriveDetailFromAppSummary(s: AppStoreSummary): AppCardDetail {
+  return {
+    status: "runnable", // App Store 只存闭环应用
+    evidenceCount: 6,
+    blocked: false,
+    entities: s.entity_count || 0,
+    pages: s.page_count || 0,
+    flowNodes: 0,
+    roles: 0,
+    aiCaps: 0,
+    identity:
+      s.product_name || s.theme_id
+        ? {
+            productName: s.product_name || "",
+            theme: s.theme_id || "azure",
+            icon: "boxes", // 摘要不含 icon，默认；模型加载后升级
+          }
+        : null,
+    pageNames: [],
+    entityNames: [],
+    stableDigest: undefined,
+    model: null, // 懒加载：卡进视口再 getApp 拉完整模型
+  };
+}
+
+/**
+ * 画廊统一条目（两条数据源合流）：
+ *   - source "app"     ── App Store 闭环应用（有血缘/版本，可复刻、可删记录）
+ *   - source "session" ── 尚未落库的在推演会话草稿（推演中/blocked）
+ * 卡片 UI 一套壳，只按 source 分派封面来源 / 菜单动作。
+ */
+export interface GalleryItem {
+  key: string;
+  source: "app" | "session";
+  goal: string;
+  createdAt?: string | null;
+  lastActive?: string | null;
+  /** session 源必有；app 源 = 记录里的 session_id（可能为空） */
+  sessionId?: string;
+  /** app 源必有：App Store 记录 id（复刻/删记录/按 id 拉模型） */
+  appId?: string;
+  rootId?: string;
+  parentId?: string | null;
+  version?: number;
+  /** app 源必有：列表摘要（模型加载前即时渲染卡片） */
+  summary?: AppStoreSummary;
+  phase?: string | null;
+}
+
+/**
+ * 合并两条数据源：App Store 闭环应用（主）∪ 未落库的在推演会话草稿。
+ * 按 session_id 去重——某个会话已闭环落库（App Store 里有），就不再把它的会话
+ * 草稿卡重复摆出来（App Store 卡取代之，因为它带血缘/版本/可复刻）。
+ * 保证零回退：当前所有会话卡仍在，只是闭环的那些改由 App Store 卡承载。
+ */
+export function mergeGalleryItems(
+  apps: AppStoreSummary[],
+  sessions: SessionListItem[]
+): GalleryItem[] {
+  const appItems: GalleryItem[] = apps.map(a => ({
+    key: `app:${a.id}`,
+    source: "app",
+    goal: a.goal || a.product_name || "",
+    createdAt: a.created_at,
+    lastActive: a.created_at,
+    sessionId: a.session_id || undefined,
+    appId: a.id,
+    rootId: a.root_id,
+    parentId: a.parent_id,
+    version: a.version,
+    summary: a,
+  }));
+  const claimed = new Set(
+    apps.map(a => a.session_id).filter((x): x is string => Boolean(x))
+  );
+  const sessionItems: GalleryItem[] = sessions
+    .filter(s => s.sessionId && !claimed.has(s.sessionId))
+    .map(s => ({
+      key: `session:${s.sessionId}`,
+      source: "session",
+      goal: s.goal,
+      createdAt: s.createdAt,
+      lastActive: s.lastActive,
+      sessionId: s.sessionId,
+      phase: s.phase,
+    }));
+  return [...appItems, ...sessionItems];
 }
 
 export type GalleryFilter = "all" | "runnable" | "draft" | "blocked";
 
 /** 筛选口径 = 门语言（E41）：closed 6/6（runnable）/ blocked / 推演中（其余）。 */
-export function filterCards(
-  items: Array<{ item: SessionListItem; detail: AppCardDetail | null }>,
-  filter: GalleryFilter,
-  query: string
-) {
+export function filterCards<
+  T extends { item: { goal: string }; detail: AppCardDetail | null },
+>(items: T[], filter: GalleryFilter, query: string): T[] {
   const q = query.trim().toLowerCase();
   return items.filter(({ item, detail }) => {
     if (q && !item.goal.toLowerCase().includes(q)) return false;
@@ -430,7 +555,11 @@ export interface BuiltinExample {
 export const PENDING_TEMPLATE_INTENT_KEY = "sliderule:pending-template-intent";
 
 export function AppsWorkbench() {
+  // 两条数据源：apps = App Store 闭环应用（摘要，有血缘/版本/可复刻）；
+  // sessions = 会话（含尚未落库的在推演草稿）。合并成画廊条目（mergeGalleryItems）。
+  const [apps, setApps] = React.useState<AppStoreSummary[] | null>(null);
   const [sessions, setSessions] = React.useState<SessionListItem[] | null>(null);
+  // 详情按画廊条目 key（app:<id> / session:<id>）索引——两条源共用一张 map。
   const [details, setDetails] = React.useState<Record<string, AppCardDetail | null>>({});
   const [listError, setListError] = React.useState<string | null>(null);
   // 三服务健康（原观察台独有价值下放：点健康点展开分列详情）
@@ -463,7 +592,8 @@ export function AppsWorkbench() {
     let alive = true;
     if (IS_GITHUB_PAGES) {
       // 静态演示（无后端）：画廊 = 主演示会话 + 画廊示例种子（E18：新引擎
-      // 真实推演的闭环终态，懒加载不进主包）。不打任何 /api/*。
+      // 真实推演的闭环终态，懒加载不进主包）。不打任何 /api/*。App Store 无后端 → 空。
+      setApps([]);
       const store = createGithubPagesSlideRuleSessionStore();
       void Promise.all([
         loadOrSeedGithubPagesDemoSession(store),
@@ -473,54 +603,86 @@ export function AppsWorkbench() {
       ])
         .then(([demoState, examples]) => {
           if (!alive) return;
-          setSessions([
+          const sessionList: SessionListItem[] = [
             { sessionId: GITHUB_PAGES_DEMO_SESSION_ID, goal: GITHUB_PAGES_DEMO_GOAL },
             ...examples.map(e => ({ sessionId: e.sessionId, goal: e.goal })),
-          ]);
+          ];
+          setSessions(sessionList);
+          // 演示态详情按合并后的条目 key（session:<id>）索引，跟真实态口径一致。
           setDetails({
-            [GITHUB_PAGES_DEMO_SESSION_ID]: deriveAppCardDetail(demoState),
+            [`session:${GITHUB_PAGES_DEMO_SESSION_ID}`]: deriveAppCardDetail(demoState),
             ...Object.fromEntries(
-              examples.map(e => [e.sessionId, deriveAppCardDetail(e.state)])
+              examples.map(e => [`session:${e.sessionId}`, deriveAppCardDetail(e.state)])
             ),
           });
         })
-        .catch(() => alive && setSessions([]));
+        .catch(() => alive && (setSessions([]), setApps([])));
       return () => {
         alive = false;
       };
     }
-    fetch("/api/sliderule/sessions")
-      .then(r => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
-      .then(data => {
+    // 真实态：并行拉两条源（App Store 摘要 + 会话列表），合并后按卡渐进拉详情。
+    // App Store 失败 fail-open 空数组（画廊退化成纯会话卡，零回退）。
+    const loadDetail = async (gi: GalleryItem) => {
+      try {
+        if (gi.source === "app" && gi.appId) {
+          const rec = await getApp(gi.appId);
+          if (!alive) return;
+          setDetails(prev => ({
+            ...prev,
+            [gi.key]: rec
+              ? deriveDetailFromAppRecord(rec.model_json) // 完整模型 → 活渲染 + 全指标
+              : gi.summary
+                ? deriveDetailFromAppSummary(gi.summary) // 拉不到详情退摘要占位
+                : null,
+          }));
+        } else if (gi.sessionId) {
+          const res = await fetch(`/api/sliderule/sessions/${encodeURIComponent(gi.sessionId)}`);
+          const body = res.ok ? await res.json() : null;
+          if (!alive) return;
+          setDetails(prev => ({
+            ...prev,
+            [gi.key]: body?.state ? deriveAppCardDetail(body.state) : null,
+          }));
+        }
+      } catch {
         if (!alive) return;
-        const list: SessionListItem[] = (data?.sessions ?? []).filter(
+        setDetails(prev => ({
+          ...prev,
+          [gi.key]: gi.source === "app" && gi.summary ? deriveDetailFromAppSummary(gi.summary) : null,
+        }));
+      }
+    };
+    void Promise.allSettled([
+      listApps(),
+      fetch("/api/sliderule/sessions").then(r =>
+        r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))
+      ),
+    ]).then(([appsRes, sessRes]) => {
+      if (!alive) return;
+      const appList = appsRes.status === "fulfilled" ? appsRes.value : [];
+      setApps(appList);
+      let sessionList: SessionListItem[] = [];
+      if (sessRes.status === "fulfilled") {
+        sessionList = ((sessRes.value?.sessions ?? []) as SessionListItem[]).filter(
           (s: SessionListItem) => s.sessionId
         );
-        setSessions(list);
-        // 渐进拉详情（并发 4；失败标 null 不武断）
-        const queue = [...list];
-        const workers = Array.from({ length: 4 }, async () => {
-          for (;;) {
-            const item = queue.shift();
-            if (!item || !alive) return;
-            try {
-              const res = await fetch(`/api/sliderule/sessions/${encodeURIComponent(item.sessionId)}`);
-              const body = res.ok ? await res.json() : null;
-              if (!alive) return;
-              setDetails(prev => ({
-                ...prev,
-                [item.sessionId]: body?.state ? deriveAppCardDetail(body.state) : null,
-              }));
-            } catch {
-              if (!alive) return;
-              setDetails(prev => ({ ...prev, [item.sessionId]: null }));
-            }
-          }
-        });
-        void Promise.all(workers);
-      })
-      .catch(e => alive && setListError(String(e?.message ?? e)));
-    if (IS_GITHUB_PAGES) return () => { alive = false; }; // 演示态不探测
+        setSessions(sessionList);
+      } else {
+        setSessions([]);
+        setListError(String((sessRes.reason as Error)?.message ?? sessRes.reason));
+      }
+      // 渐进拉详情（并发 4；app→getApp 完整模型 / session→会话态；失败退占位/ null）
+      const queue = mergeGalleryItems(appList, sessionList);
+      const workers = Array.from({ length: 4 }, async () => {
+        for (;;) {
+          const gi = queue.shift();
+          if (!gi || !alive) return;
+          await loadDetail(gi);
+        }
+      });
+      void Promise.all(workers);
+    });
     fetch("/api/sliderule/builtin-examples")
       .then(r => (r.ok ? r.json() : null))
       .then(d => alive && setExamples(Array.isArray(d?.examples) ? d.examples : []))
@@ -570,24 +732,30 @@ export function AppsWorkbench() {
     open(newSessionId());
   };
 
-  const removeApp = async (sessionId: string) => {
-    // DELETE 幂等（G1 契约）；成功后本地摘卡，不整页刷新
+  /** 删卡：App Store 卡删记录（DELETE /apps/{id}，不动会话）；会话草稿卡删会话。 */
+  const removeCard = async (gi: GalleryItem) => {
     try {
-      await fetch(`/api/sliderule/sessions/${encodeURIComponent(sessionId)}`, {
-        method: "DELETE",
-      });
-      const remaining = (sessions ?? []).filter(s => s.sessionId !== sessionId);
-      setSessions(remaining);
-      // E28：与左侧会话列表联动——广播更新事件让侧栏立即摘掉该会话；
-      // 删的是当前活跃会话时切到最近剩余会话（一个不剩就开新会话），
-      // 避免 active-session-id 悬空指向已删会话
-      notifySessionsUpdated();
-      try {
-        if (localStorage.getItem(ACTIVE_SESSION_KEY) === sessionId) {
-          activateSession(remaining[0]?.sessionId ?? newSessionId());
+      if (gi.source === "app" && gi.appId) {
+        const ok = await deleteApp(gi.appId);
+        if (ok) setApps(prev => (prev ?? []).filter(a => a.id !== gi.appId));
+      } else if (gi.sessionId) {
+        // DELETE 幂等（G1 契约）；成功后本地摘卡，不整页刷新
+        await fetch(`/api/sliderule/sessions/${encodeURIComponent(gi.sessionId)}`, {
+          method: "DELETE",
+        });
+        const remaining = (sessions ?? []).filter(s => s.sessionId !== gi.sessionId);
+        setSessions(remaining);
+        // E28：与左侧会话列表联动——广播更新事件让侧栏立即摘掉该会话；
+        // 删的是当前活跃会话时切到最近剩余会话（一个不剩就开新会话），
+        // 避免 active-session-id 悬空指向已删会话
+        notifySessionsUpdated();
+        try {
+          if (localStorage.getItem(ACTIVE_SESSION_KEY) === gi.sessionId) {
+            activateSession(remaining[0]?.sessionId ?? newSessionId());
+          }
+        } catch {
+          /* 隐私模式无存储：跳过活跃会话纠正 */
         }
-      } catch {
-        /* 隐私模式无存储：跳过活跃会话纠正 */
       }
     } catch {
       /* 网络失败保持原样，用户可重试 */
@@ -595,9 +763,30 @@ export function AppsWorkbench() {
     setMenuFor(null);
   };
 
-  const paired = (sessions ?? []).map(item => ({
+  /**
+   * 复刻（②，对标 Budibase duplicateApp / Appsmith fork / ToolJet clone）：
+   * 以某个 App Store 应用为起点分出一条新血缘（新 root·v1·parent 指向源），
+   * 成功后重拉画廊——新卡出现在列表里，用户可点开继续改。后端 fork_app 现成。
+   */
+  const forkAppCard = async (gi: GalleryItem) => {
+    setMenuFor(null);
+    if (gi.source !== "app" || !gi.appId) return;
+    const newId = await forkApp(gi.appId);
+    if (newId) setReloadKey(k => k + 1);
+  };
+
+  // 合并两条数据源为画廊条目；详情按条目 key 索引，app 卡在模型加载前用摘要占位。
+  const items: GalleryItem[] | null =
+    apps === null && sessions === null
+      ? null
+      : mergeGalleryItems(apps ?? [], sessions ?? []);
+  const paired = (items ?? []).map(item => ({
     item,
-    detail: details[item.sessionId] ?? null,
+    detail:
+      details[item.key] ??
+      (item.source === "app" && item.summary
+        ? deriveDetailFromAppSummary(item.summary)
+        : null),
   }));
   paired.sort((a, b) => {
     const ka = String(a.item.lastActive ?? a.item.createdAt ?? "");
@@ -839,7 +1028,7 @@ export function AppsWorkbench() {
       {tab === "mine" &&
         (listError ? (
           <div className="mt-8 text-[13px] text-red-500">会话列表拉取失败：{listError}</div>
-        ) : sessions == null ? (
+        ) : items == null ? (
           <div className="mt-8 text-[13px] text-stone-400">加载中…</div>
         ) : visible.length === 0 ? (
           <div className="mt-8 text-[13px] text-stone-400">
@@ -852,17 +1041,22 @@ export function AppsWorkbench() {
               const BrandIcon = detail?.identity
                 ? BRAND_LUCIDE[detail.identity.icon] ?? Boxes
                 : undefined;
+              // 活渲染缩略图的稳定 id：会话卡用 sessionId，App Store 卡无会话时用 appId。
+              const thumbId = item.sessionId || item.appId || item.key;
+              const canOpen = Boolean(item.sessionId);
+              const isApp = item.source === "app";
+              const version = item.version ?? 1;
               return (
                 <CenterCard
-                  key={item.sessionId}
-                  testid={`app-card-${item.sessionId}`}
+                  key={item.key}
+                  testid={`app-card-${item.sessionId || item.appId}`}
                   title={detail?.identity?.productName || item.goal || "（未命名话题）"}
                   titleAttr={item.goal}
                   Icon={BrandIcon}
                   iconBg={detail?.identity ? themePrimary(detail.identity.theme) : undefined}
                   media={
                     detail?.status === "runnable" && detail.model ? (
-                      <LiveAppThumb sessionId={item.sessionId} model={detail.model} goal={item.goal} />
+                      <LiveAppThumb sessionId={thumbId} model={detail.model} goal={item.goal} />
                     ) : (
                       <PendingAppThumb detail={detail} />
                     )
@@ -882,6 +1076,14 @@ export function AppsWorkbench() {
                           <GitBranch size={11} className="opacity-60" />
                           AI {detail.aiCaps}
                         </span>
+                        {isApp && version > 1 && (
+                          <span
+                            className="inline-flex items-center rounded bg-white/20 px-1.5 text-[10px] font-semibold text-white/95"
+                            title="改版次数（App Store 血缘）"
+                          >
+                            v{version}
+                          </span>
+                        )}
                       </>
                     ) : (
                       <span className="opacity-70">加载中…</span>
@@ -889,27 +1091,36 @@ export function AppsWorkbench() {
                   }
                   statusDot={meta?.dot ?? "bg-stone-300"}
                   statusLabel={meta?.label ?? "…"}
-                  onClick={() => open(item.sessionId)}
+                  onClick={() => (canOpen ? open(item.sessionId!) : undefined)}
                   topRight={
                     <>
                       <button
-                        data-testid={`app-menu-${item.sessionId}`}
+                        data-testid={`app-menu-${item.sessionId || item.appId}`}
                         className="absolute right-2 top-2 rounded bg-white/85 p-1 text-stone-400 opacity-0 shadow-sm transition hover:text-stone-600 group-hover:opacity-100"
                         onClick={e => {
                           e.stopPropagation();
-                          setMenuFor(prev => (prev === item.sessionId ? null : item.sessionId));
+                          setMenuFor(prev => (prev === item.key ? null : item.key));
                         }}
                       >
                         <MoreHorizontal size={14} />
                       </button>
-                      {menuFor === item.sessionId && (
+                      {menuFor === item.key && (
                         <div
                           className="absolute right-2 top-8 z-10 rounded-lg border border-stone-200 bg-white py-1 shadow-lg"
                           onClick={e => e.stopPropagation()}
                         >
+                          {isApp && (
+                            <button
+                              data-testid={`app-fork-${item.appId}`}
+                              className="flex w-full items-center gap-2 px-3 py-1.5 text-[12px] text-slate-600 hover:bg-slate-50"
+                              onClick={() => void forkAppCard(item)}
+                            >
+                              <GitBranch size={13} /> 复刻应用
+                            </button>
+                          )}
                           <button
                             className="flex w-full items-center gap-2 px-3 py-1.5 text-[12px] text-red-500 hover:bg-red-50"
-                            onClick={() => void removeApp(item.sessionId)}
+                            onClick={() => void removeCard(item)}
                           >
                             <Trash2 size={13} /> 删除应用
                           </button>

--- a/client/src/pages/agent-loop/dashboard/__tests__/apps-workbench.test.ts
+++ b/client/src/pages/agent-loop/dashboard/__tests__/apps-workbench.test.ts
@@ -10,6 +10,7 @@ import {
   mergeGalleryItems,
   filterCards,
   formatUpdatedAt,
+  formatRelativeTime,
   type SessionListItem,
 } from "../AppsWorkbench";
 import type { AppStoreSummary } from "../app-store-client";
@@ -195,5 +196,27 @@ describe("formatUpdatedAt", () => {
     expect(formatUpdatedAt("2026-07-15T06:17:00Z")).toMatch(/^2026-07-15 \d{2}:\d{2}$/);
     expect(formatUpdatedAt("garbage")).toBe("");
     expect(formatUpdatedAt(null)).toBe("");
+  });
+});
+
+describe("formatRelativeTime", () => {
+  const now = new Date("2026-07-26T12:00:00Z").getTime();
+  const ago = (ms: number) => new Date(now - ms).toISOString();
+  const S = 1000, M = 60 * S, H = 60 * M, D = 24 * H;
+
+  it("按跨度给人话，绝对时间由调用方兜底", () => {
+    expect(formatRelativeTime(ago(10 * S), now)).toBe("刚刚");
+    expect(formatRelativeTime(ago(5 * M), now)).toBe("5 分钟前");
+    expect(formatRelativeTime(ago(3 * H), now)).toBe("3 小时前");
+    expect(formatRelativeTime(ago(1 * D), now)).toBe("昨天");
+    expect(formatRelativeTime(ago(4 * D), now)).toBe("4 天前");
+    expect(formatRelativeTime(ago(2 * 7 * D), now)).toBe("2 周前");
+    expect(formatRelativeTime(ago(90 * D), now)).toBe("3 个月前");
+    expect(formatRelativeTime(ago(400 * D), now)).toBe("1 年前");
+  });
+
+  it("空/坏输入回空串", () => {
+    expect(formatRelativeTime(null, now)).toBe("");
+    expect(formatRelativeTime("garbage", now)).toBe("");
   });
 });

--- a/client/src/pages/agent-loop/dashboard/__tests__/apps-workbench.test.ts
+++ b/client/src/pages/agent-loop/dashboard/__tests__/apps-workbench.test.ts
@@ -5,10 +5,14 @@
 import { describe, it, expect } from "vitest";
 import {
   deriveAppCardDetail,
+  deriveDetailFromAppSummary,
+  deriveDetailFromAppRecord,
+  mergeGalleryItems,
   filterCards,
   formatUpdatedAt,
   type SessionListItem,
 } from "../AppsWorkbench";
+import type { AppStoreSummary } from "../app-store-client";
 
 const runnableState = {
   publishClosure: {
@@ -92,6 +96,97 @@ describe("filterCards", () => {
   it("搜索按话题子串过滤", () => {
     expect(filterCards(cards, "all", "宠物")).toHaveLength(1);
     expect(filterCards(cards, "all", "不存在")).toHaveLength(0);
+  });
+});
+
+const summary = (over: Partial<AppStoreSummary> = {}): AppStoreSummary => ({
+  id: "app1",
+  root_id: "app1",
+  parent_id: null,
+  version: 1,
+  session_id: "s1",
+  goal: "咖啡店管理",
+  gate_passed: true,
+  created_at: "2026-07-24T10:00:00Z",
+  product_name: "咖营通",
+  theme_id: "forest",
+  theme_label: "松绿·测试",
+  device: "desktop",
+  landing_page_ref: "p0",
+  entity_count: 3,
+  page_count: 4,
+  ...over,
+});
+
+describe("deriveDetailFromAppSummary", () => {
+  it("App Store 摘要 → 即时 runnable 占位，计数取摘要、模型待懒拉", () => {
+    const d = deriveDetailFromAppSummary(summary());
+    expect(d.status).toBe("runnable"); // App Store 只存闭环应用
+    expect(d.entities).toBe(3);
+    expect(d.pages).toBe(4);
+    expect(d.model).toBeNull(); // 摘要不含模型，进视口再拉
+    expect(d.identity?.productName).toBe("咖营通");
+    expect(d.identity?.theme).toBe("forest");
+  });
+});
+
+describe("deriveDetailFromAppRecord", () => {
+  it("完整 model_json → 全指标 + 活渲染模型（与会话卡同源口径）", () => {
+    const model = {
+      datamodel: { entities: [{ name: "订单" }, { name: "商品" }] },
+      page: { pages: [{ id: "p0", name: "监控台" }] },
+      workflow: { nodes: [{ id: "n1" }] },
+      rbac: { roles: ["店长", "店员"] },
+      aigc: { capabilities: [{ id: "c1" }] },
+      appbundle: { appIdentity: { productName: "咖营通", theme: "forest", icon: "cart" } },
+    };
+    const d = deriveDetailFromAppRecord(model);
+    expect(d.status).toBe("runnable");
+    expect(d.entities).toBe(2);
+    expect(d.pages).toBe(1);
+    expect(d.roles).toBe(2);
+    expect(d.aiCaps).toBe(1);
+    expect(d.identity?.icon).toBe("cart");
+    expect(d.model).not.toBeNull();
+  });
+
+  it("坏 model_json（非对象）→ 不崩，退成空指标 draft", () => {
+    expect(deriveDetailFromAppRecord(null).model).toBeNull();
+    expect(deriveDetailFromAppRecord("nope").entities).toBe(0);
+  });
+});
+
+describe("mergeGalleryItems", () => {
+  const sess = (id: string, goal: string): SessionListItem => ({ sessionId: id, goal });
+
+  it("App Store 应用 + 未落库会话草稿合流，按 session_id 去重", () => {
+    const apps = [summary({ id: "app1", session_id: "s1" })];
+    const sessions = [sess("s1", "咖啡店（已闭环）"), sess("s2", "健身房（在推演）")];
+    const items = mergeGalleryItems(apps, sessions);
+    // s1 已被 App Store 卡承载 → 不再出会话草稿卡；只剩 app1 + s2
+    expect(items.map(i => i.key).sort()).toEqual(["app:app1", "session:s2"]);
+    const appItem = items.find(i => i.source === "app")!;
+    expect(appItem.appId).toBe("app1");
+    expect(appItem.version).toBe(1);
+    const draft = items.find(i => i.source === "session")!;
+    expect(draft.sessionId).toBe("s2");
+  });
+
+  it("无 App Store（空）→ 全是会话卡，零回退", () => {
+    const items = mergeGalleryItems([], [sess("s1", "a"), sess("s2", "b")]);
+    expect(items).toHaveLength(2);
+    expect(items.every(i => i.source === "session")).toBe(true);
+  });
+});
+
+describe("filterCards（含 App Store 卡）", () => {
+  it("App Store 摘要卡即时算 runnable，进 runnable 筛选", () => {
+    const cards = [
+      { item: { goal: "咖营通" }, detail: deriveDetailFromAppSummary(summary()) },
+      { item: { goal: "草稿" }, detail: deriveAppCardDetail({}) },
+    ];
+    expect(filterCards(cards, "runnable", "")).toHaveLength(1);
+    expect(filterCards(cards, "draft", "")).toHaveLength(1);
   });
 });
 

--- a/client/src/pages/agent-loop/dashboard/app-store-client.ts
+++ b/client/src/pages/agent-loop/dashboard/app-store-client.ts
@@ -88,13 +88,15 @@ export async function listVersions(rootId: string): Promise<AppStoreSummary[]> {
 
 /**
  * 以某个生成应用为起点分出一条新血缘（新 root · v1 · parent 指向源）。
- * 对标 ToolJet clone / Budibase duplicateApp：成功返回新 app id，失败返回 null。
+ * 对标 ToolJet clone / Budibase duplicateApp：传 name 给副本改名（避免同名孪生卡）。
+ * 成功返回新 app id，失败返回 null。
  */
-export async function forkApp(id: string): Promise<string | null> {
+export async function forkApp(id: string, name?: string): Promise<string | null> {
   try {
     const res = await fetch(`${BASE}/apps/${encodeURIComponent(id)}/fork`, {
       method: "POST",
       headers: { accept: "application/json", "content-type": "application/json" },
+      body: JSON.stringify(name && name.trim() ? { name: name.trim() } : {}),
     });
     if (!res.ok) return null;
     const data = (await res.json()) as { id?: string };

--- a/client/src/pages/agent-loop/dashboard/app-store-client.ts
+++ b/client/src/pages/agent-loop/dashboard/app-store-client.ts
@@ -1,0 +1,121 @@
+/**
+ * App Store 前端客户端（2026-07-25）——「生成应用」持久层（services/app_store.py）
+ * 的前端取数入口。应用中心画廊从这里读「已闭环 · 有血缘 · 可复刻」的真数据。
+ *
+ * 设计对标 ToolJet 的 `frontend/src/_services/apps.service.js`（审计过的成熟实现）：
+ *   getAll(page, folder, search, type)  →  listApps({limit, offset})    列表要「摘要」
+ *   getApp(id)                          →  getApp(id)                    详情才拉「完整模型」
+ *   getVersions(id)                     →  listVersions(rootId)          改版历史
+ *   clone(id)  → POST /apps/{id}/clone  →  forkApp(id)                   复刻（新血缘）
+ * ——即「列表只拉轻量摘要、完整定义按需再取」的两级取数。我们的差异化在于卡片封面
+ * 用真实活渲染（AppRuntimeScreen），所以完整模型仍按卡懒拉，但列表本身保持轻。
+ *
+ * 全部走 Node 薄代理 `/api/sliderule/*`（server/routes/sliderule.ts 尾部 catch-all
+ * 透传到 Python 并补 X-Internal-Key），前端不碰内部密钥。静态演示（GitHub Pages）
+ * 无后端，调用方需自行短路，不要打这些接口。
+ */
+
+/** 列表摘要——对应 Python `_summary`（去掉 model_json 大载荷）。 */
+export interface AppStoreSummary {
+  id: string;
+  root_id: string;
+  parent_id: string | null;
+  version: number;
+  session_id: string | null;
+  goal: string;
+  gate_passed: boolean;
+  created_at: string;
+  product_name: string;
+  theme_id: string;
+  theme_label: string;
+  device: string;
+  landing_page_ref: string;
+  entity_count: number;
+  page_count: number;
+}
+
+/** 完整记录——摘要 + model_json（可直接重开渲染）。 */
+export interface AppStoreRecord extends AppStoreSummary {
+  model_json: unknown;
+}
+
+const BASE = "/api/sliderule";
+
+async function getJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return (await res.json()) as T;
+}
+
+/**
+ * 应用画廊列表——默认每个应用只出最新版，摘要不含大模型载荷。
+ * 对标 ToolJet getAll：翻页/条数是服务端参数，不在前端全量切片。
+ */
+export async function listApps(
+  opts: { limit?: number; offset?: number } = {}
+): Promise<AppStoreSummary[]> {
+  const limit = opts.limit ?? 200;
+  const offset = opts.offset ?? 0;
+  const data = await getJson<{ apps?: AppStoreSummary[] }>(
+    `${BASE}/apps?limit=${limit}&offset=${offset}`
+  );
+  return Array.isArray(data?.apps) ? data.apps : [];
+}
+
+/**
+ * 取一个生成应用的完整记录（含 model_json）——卡片进入视口时才拉，
+ * 用于活渲染缩略图 / 点开重渲。404 或网络失败返回 null（调用方走占位）。
+ */
+export async function getApp(id: string): Promise<AppStoreRecord | null> {
+  try {
+    return await getJson<AppStoreRecord>(`${BASE}/apps/${encodeURIComponent(id)}`);
+  } catch {
+    return null;
+  }
+}
+
+/** 一个应用的改版历史（同 root 的所有版本，按 version 升序，摘要）。 */
+export async function listVersions(rootId: string): Promise<AppStoreSummary[]> {
+  try {
+    const data = await getJson<{ versions?: AppStoreSummary[] }>(
+      `${BASE}/apps/${encodeURIComponent(rootId)}/versions`
+    );
+    return Array.isArray(data?.versions) ? data.versions : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * 以某个生成应用为起点分出一条新血缘（新 root · v1 · parent 指向源）。
+ * 对标 ToolJet clone / Budibase duplicateApp：成功返回新 app id，失败返回 null。
+ */
+export async function forkApp(id: string): Promise<string | null> {
+  try {
+    const res = await fetch(`${BASE}/apps/${encodeURIComponent(id)}/fork`, {
+      method: "POST",
+      headers: { accept: "application/json", "content-type": "application/json" },
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { id?: string };
+    return typeof data?.id === "string" ? data.id : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 从画廊移除一个应用记录（只删记录，不动对应推演会话）。返回是否删成功。
+ * 对标三家的 deleteApp：DELETE 幂等，失败/网络异常返回 false 让调用方保持原样。
+ */
+export async function deleteApp(id: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${BASE}/apps/${encodeURIComponent(id)}`, {
+      method: "DELETE",
+      headers: { accept: "application/json" },
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,66 @@
+# Render 蓝图（Blueprint）—— SlideRule / WhyBuddy 两服务一键部署
+#
+# 用法：Render → New → Blueprint → 选这个仓库（分支 main）→ Apply。
+# Render 会照这份文件自动建好两个服务、把内部地址和共享密钥接好、挂好数据盘，
+# 你只需在 Apply 时手填几个标了 sync:false 的密钥（LLM_API_KEY 等）。
+#
+# 拓扑（跟 docker-compose.prod.yml 一致）：
+#   whybuddy-python  —— FastAPI 推演后端，私有服务（只给 Node 内部调，不公开）
+#   whybuddy         —— Node（前端 + API），公开 Web 服务，代理 /api/sliderule 到 Python
+#
+# 说明：
+# - dockerContext 必须是仓库根（.），否则 Python Dockerfile 里的
+#   COPY docker/certs / COPY slide-rule-python 会找不到。
+# - 两个服务同 region，私网才通。
+# - 端口：Render 默认注入 $PORT=10000，两个镜像的启动命令都已改成听 $PORT，
+#   所以 Python 监听 10000、Node 用 http://whybuddy-python:10000 连它。
+#   （若在面板看到 Python 实际内部端口不是 10000，把下面三个 URL 的端口改一致即可。）
+
+services:
+  # ── Python 推演后端（私有服务）──────────────────────────────────
+  - type: pserv
+    name: whybuddy-python
+    runtime: docker
+    branch: main
+    region: singapore
+    plan: starter                 # 私有服务 + 挂盘需付费档（$7/月起）
+    dockerfilePath: ./slide-rule-python/Dockerfile
+    dockerContext: .
+    healthCheckPath: /health
+    disk:
+      name: whybuddy-python-data
+      mountPath: /app/data        # 会话 / 生成应用落这儿，挂盘后重启不丢
+      sizeGB: 1
+    envVars:
+      - key: SLIDE_RULE_INTERNAL_KEY
+        generateValue: true        # Render 随机生成；Node 那边引用同一个值
+      - key: LLM_API_KEY
+        sync: false                # Apply 时在面板填（推演必需）
+      # 如不用默认 provider，再在面板补 LLM_BASE_URL / LLM_MODEL
+
+  # ── Node（前端 + API，公开）──────────────────────────────────────
+  - type: web
+    name: whybuddy
+    runtime: docker
+    branch: main
+    region: singapore
+    plan: starter                 # 展会不想冷启动就用付费档；平时可改 free（会休眠）
+    dockerfilePath: ./Dockerfile
+    dockerContext: .
+    healthCheckPath: /
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: SLIDERULE_V5_BACKEND
+        value: python
+      - key: PYTHON_SLIDE_RULE_BASE_URL
+        value: http://whybuddy-python:10000
+      - key: PYTHON_API_TARGET
+        value: http://whybuddy-python:10000
+      - key: AGENT_LOOP_API_TARGET
+        value: http://whybuddy-python:10000
+      - key: PYTHON_SLIDE_RULE_INTERNAL_KEY
+        fromService:               # 引用 Python 服务生成的同一把密钥
+          type: pserv
+          name: whybuddy-python
+          envVarKey: SLIDE_RULE_INTERNAL_KEY

--- a/render.yaml
+++ b/render.yaml
@@ -23,11 +23,11 @@ services:
     plan: free
     dockerfilePath: ./slide-rule-python/Dockerfile
     dockerContext: .
-    # 不设 healthCheckPath：Render 靠 TCP 端口探测判活即可。之前设 /health 时，
-    # uvicorn 默认绑 :: (IPv6)、而 Render 健康检查走 IPv4 → 连不上超时、部署失败。
+    # 健康检查指向 /health（返回 200）。不能留空/默认——Render 默认会探根路径 /，
+    # 而本应用 / 没有路由、返回 404，Render 一看非成功码就判失败超时。
+    # 绑定保持 :: 默认：实测 Render 探针从 ::1(IPv6 本地) 打进来，:: 能收到、能响应。
+    healthCheckPath: /health
     envVars:
-      - key: UVICORN_HOST
-        value: "0.0.0.0"           # Render 私网/健康检查走 IPv4，绑 0.0.0.0（不是 ::）
       - key: SLIDE_RULE_INTERNAL_KEY
         generateValue: true        # 随机生成；Node 那边引用同一个值（内部 API 靠它挡）
       - key: LLM_API_KEY
@@ -42,8 +42,8 @@ services:
     plan: free
     dockerfilePath: ./Dockerfile
     dockerContext: .
-    # 不设 healthCheckPath：靠 TCP 端口探测判活，避开健康检查门的绑定/时序坑。
-    # Node server.listen(port) 默认双栈、收 IPv4；公网路由由 Render 边缘负责，不受影响。
+    # Node 在 / 提供前端页面（返回 200），健康检查指向 / 即可。
+    healthCheckPath: /
     envVars:
       - key: NODE_ENV
         value: production

--- a/render.yaml
+++ b/render.yaml
@@ -1,50 +1,42 @@
-# Render 蓝图（Blueprint）—— SlideRule / WhyBuddy 两服务一键部署
+# Render 蓝图（Blueprint）—— SlideRule / WhyBuddy【全免费版】
 #
-# 用法：Render → New → Blueprint → 选这个仓库（分支 main）→ Apply。
-# Render 会照这份文件自动建好两个服务、把内部地址和共享密钥接好、挂好数据盘，
-# 你只需在 Apply 时手填几个标了 sync:false 的密钥（LLM_API_KEY 等）。
+# 用法：Render → New → Blueprint → 选这个仓库（分支 main）→ Apply，
+# Apply 时填一个 LLM_API_KEY 即可。
 #
-# 拓扑（跟 docker-compose.prod.yml 一致）：
-#   whybuddy-python  —— FastAPI 推演后端，私有服务（只给 Node 内部调，不公开）
-#   whybuddy         —— Node（前端 + API），公开 Web 服务，代理 /api/sliderule 到 Python
+# 免费版取舍（Render 免费档只覆盖「公开 Web 服务」，私有服务/数据盘都要付费）：
+#   - Python 从「私有服务」改成「公开 Web 服务」（有内部密钥挡着，但暴露在公网）；
+#   - 去掉数据盘 → 数据落临时文件系统，服务重启/重部署会丢（仅用于跑通验证；
+#     要持久我再给你加个免费 Postgres）；
+#   - 两个服务闲置 ~15 分钟休眠，首个访客要等 30~60 秒冷启动。
+#   - 免费实例全账号共享 750 小时/月（休眠时不计），够断续测试。
 #
-# 说明：
-# - dockerContext 必须是仓库根（.），否则 Python Dockerfile 里的
-#   COPY docker/certs / COPY slide-rule-python 会找不到。
-# - 两个服务同 region，私网才通。
-# - 端口：Render 默认注入 $PORT=10000，两个镜像的启动命令都已改成听 $PORT，
-#   所以 Python 监听 10000、Node 用 http://whybuddy-python:10000 连它。
-#   （若在面板看到 Python 实际内部端口不是 10000，把下面三个 URL 的端口改一致即可。）
+# 端口：Render 注入 $PORT=10000，两个镜像启动命令都听 $PORT；
+# Node 用内部地址 http://whybuddy-python:10000 连 Python。
 
 services:
-  # ── Python 推演后端（私有服务）──────────────────────────────────
-  - type: pserv
+  # ── Python 推演后端（免费公开 Web 服务）─────────────────────────
+  - type: web
     name: whybuddy-python
     runtime: docker
     branch: main
     region: singapore
-    plan: starter                 # 私有服务 + 挂盘需付费档（$7/月起）
+    plan: free
     dockerfilePath: ./slide-rule-python/Dockerfile
     dockerContext: .
-    # 私有服务（pserv）不支持 healthCheckPath——Render 会拒绝蓝图，故不设。
-    disk:
-      name: whybuddy-python-data
-      mountPath: /app/data        # 会话 / 生成应用落这儿，挂盘后重启不丢
-      sizeGB: 1
+    healthCheckPath: /health
     envVars:
       - key: SLIDE_RULE_INTERNAL_KEY
-        generateValue: true        # Render 随机生成；Node 那边引用同一个值
+        generateValue: true        # 随机生成；Node 那边引用同一个值（内部 API 靠它挡）
       - key: LLM_API_KEY
         sync: false                # Apply 时在面板填（推演必需）
-      # 如不用默认 provider，再在面板补 LLM_BASE_URL / LLM_MODEL
 
-  # ── Node（前端 + API，公开）──────────────────────────────────────
+  # ── Node（前端 + API，免费公开 Web 服务）─────────────────────────
   - type: web
     name: whybuddy
     runtime: docker
     branch: main
     region: singapore
-    plan: starter                 # 展会不想冷启动就用付费档；平时可改 free（会休眠）
+    plan: free
     dockerfilePath: ./Dockerfile
     dockerContext: .
     healthCheckPath: /
@@ -61,6 +53,6 @@ services:
         value: http://whybuddy-python:10000
       - key: PYTHON_SLIDE_RULE_INTERNAL_KEY
         fromService:               # 引用 Python 服务生成的同一把密钥
-          type: pserv
+          type: web
           name: whybuddy-python
           envVarKey: SLIDE_RULE_INTERNAL_KEY

--- a/render.yaml
+++ b/render.yaml
@@ -49,12 +49,15 @@ services:
         value: production
       - key: SLIDERULE_V5_BACKEND
         value: python
+      # 走 Python 的公网地址（不是私网 whybuddy-python:10000）——Render 服务间私网对
+      # 绑定/端口有坑（跨服务是 IPv4，:: 绑定 v6only 时收不到），走公网让 Render 边缘
+      # 处理连接，最稳；内部 API 仍靠 SLIDE_RULE_INTERNAL_KEY 挡。
       - key: PYTHON_SLIDE_RULE_BASE_URL
-        value: http://whybuddy-python:10000
+        value: https://whybuddy-python.onrender.com
       - key: PYTHON_API_TARGET
-        value: http://whybuddy-python:10000
+        value: https://whybuddy-python.onrender.com
       - key: AGENT_LOOP_API_TARGET
-        value: http://whybuddy-python:10000
+        value: https://whybuddy-python.onrender.com
       - key: PYTHON_SLIDE_RULE_INTERNAL_KEY
         fromService:               # 引用 Python 服务生成的同一把密钥
           type: web

--- a/render.yaml
+++ b/render.yaml
@@ -23,8 +23,11 @@ services:
     plan: free
     dockerfilePath: ./slide-rule-python/Dockerfile
     dockerContext: .
-    healthCheckPath: /health
+    # 不设 healthCheckPath：Render 靠 TCP 端口探测判活即可。之前设 /health 时，
+    # uvicorn 默认绑 :: (IPv6)、而 Render 健康检查走 IPv4 → 连不上超时、部署失败。
     envVars:
+      - key: UVICORN_HOST
+        value: "0.0.0.0"           # Render 私网/健康检查走 IPv4，绑 0.0.0.0（不是 ::）
       - key: SLIDE_RULE_INTERNAL_KEY
         generateValue: true        # 随机生成；Node 那边引用同一个值（内部 API 靠它挡）
       - key: LLM_API_KEY
@@ -39,7 +42,8 @@ services:
     plan: free
     dockerfilePath: ./Dockerfile
     dockerContext: .
-    healthCheckPath: /
+    # 不设 healthCheckPath：靠 TCP 端口探测判活，避开健康检查门的绑定/时序坑。
+    # Node server.listen(port) 默认双栈、收 IPv4；公网路由由 Render 边缘负责，不受影响。
     envVars:
       - key: NODE_ENV
         value: production

--- a/render.yaml
+++ b/render.yaml
@@ -26,7 +26,7 @@ services:
     plan: starter                 # 私有服务 + 挂盘需付费档（$7/月起）
     dockerfilePath: ./slide-rule-python/Dockerfile
     dockerContext: .
-    healthCheckPath: /health
+    # 私有服务（pserv）不支持 healthCheckPath——Render 会拒绝蓝图，故不设。
     disk:
       name: whybuddy-python-data
       mountPath: /app/data        # 会话 / 生成应用落这儿，挂盘后重启不丢

--- a/slide-rule-python/Dockerfile
+++ b/slide-rule-python/Dockerfile
@@ -29,9 +29,11 @@ COPY slide-rule-python/ ./
 
 EXPOSE 9700
 
-# 绑 :: = IPv4+IPv6 双栈（Railway 等平台的服务间私网是 IPv6-only，只绑 0.0.0.0
-# 会导致 Node 侧走 *.railway.internal 连不进来 → 502；:: 同时兼容 compose 的
-# IPv4 桥接网，两边都能用）。端口听平台注入的 $PORT，没有就回落 9700（compose
-# 里设了 PORT=9700，健康检查照旧命中）。用 sh -c + exec 保证 uvicorn 是 PID 1、
-# 正常接收 SIGTERM 优雅退出。
-CMD ["sh", "-c", "exec python -m uvicorn app:app --host :: --port ${PORT:-9700}"]
+# 监听地址可配（UVICORN_HOST），默认 :: = IPv4+IPv6 双栈：
+#   - Railway 服务间私网是 IPv6-only（*.railway.internal），需要 :: 才连得进；
+#   - compose 的 IPv4 桥接网 :: 也兼容（Linux 默认 v6only=0，收 IPv4-mapped）。
+# 但有些平台（如 Render）私网/健康检查走 IPv4，且容器可能 v6only=1，:: 会收不到
+# IPv4 连接 → 健康检查超时。这类平台把 UVICORN_HOST 设成 0.0.0.0 即可。
+# 端口听平台注入的 $PORT，没有回落 9700（compose 设了 PORT=9700）。
+# sh -c + exec 保证 uvicorn 是 PID 1、正常收 SIGTERM 优雅退出。
+CMD ["sh", "-c", "exec python -m uvicorn app:app --host ${UVICORN_HOST:-::} --port ${PORT:-9700}"]

--- a/slide-rule-python/Dockerfile
+++ b/slide-rule-python/Dockerfile
@@ -29,4 +29,9 @@ COPY slide-rule-python/ ./
 
 EXPOSE 9700
 
-CMD ["python", "-m", "uvicorn", "app:app", "--host", "0.0.0.0", "--port", "9700"]
+# 绑 :: = IPv4+IPv6 双栈（Railway 等平台的服务间私网是 IPv6-only，只绑 0.0.0.0
+# 会导致 Node 侧走 *.railway.internal 连不进来 → 502；:: 同时兼容 compose 的
+# IPv4 桥接网，两边都能用）。端口听平台注入的 $PORT，没有就回落 9700（compose
+# 里设了 PORT=9700，健康检查照旧命中）。用 sh -c + exec 保证 uvicorn 是 PID 1、
+# 正常接收 SIGTERM 优雅退出。
+CMD ["sh", "-c", "exec python -m uvicorn app:app --host :: --port ${PORT:-9700}"]

--- a/slide-rule-python/routes/sliderule_full.py
+++ b/slide-rule-python/routes/sliderule_full.py
@@ -1432,12 +1432,23 @@ async def list_generated_app_versions(root_id: str, x_internal_key: Optional[str
 
 
 @router.post("/apps/{app_id}/fork")
-async def fork_generated_app(app_id: str, x_internal_key: Optional[str] = Header(None)):
-    """以某个生成应用为起点分出一条新血缘（新 root·v1·parent 指向源）。"""
+async def fork_generated_app(
+    app_id: str, request: Request, x_internal_key: Optional[str] = Header(None)
+):
+    """以某个生成应用为起点分出一条新血缘（新 root·v1·parent 指向源）。
+    可选 body {name}：给副本改名（避免同名孪生卡，对标 Budibase duplicateApp）。"""
     _auth(x_internal_key)
     from services import app_store
 
-    new_id = app_store.fork_app(app_id)
+    new_name: Optional[str] = None
+    try:
+        body = await request.json()
+        if isinstance(body, dict) and isinstance(body.get("name"), str) and body["name"].strip():
+            new_name = body["name"].strip()
+    except Exception:
+        pass  # 无 body / 非 JSON → 不改名
+
+    new_id = app_store.fork_app(app_id, new_name=new_name)
     if new_id is None:
         raise HTTPException(404, "source app not found")
     return {"id": new_id}

--- a/slide-rule-python/routes/sliderule_full.py
+++ b/slide-rule-python/routes/sliderule_full.py
@@ -1443,6 +1443,17 @@ async def fork_generated_app(app_id: str, x_internal_key: Optional[str] = Header
     return {"id": new_id}
 
 
+@router.delete("/apps/{app_id}")
+async def delete_generated_app(app_id: str, x_internal_key: Optional[str] = Header(None)):
+    """从画廊移除一个生成应用记录（只删记录，不动对应推演会话）。"""
+    _auth(x_internal_key)
+    from services import app_store
+
+    if not app_store.delete_app(app_id):
+        raise HTTPException(404, "app not found")
+    return {"ok": True}
+
+
 @router.get("/apps-export")
 async def export_generated_apps(x_internal_key: Optional[str] = Header(None)):
     """导出全部应用记录（备份/迁移）——无论后端在哪，手上永远有一份可迁移真数据。"""

--- a/slide-rule-python/services/app_store.py
+++ b/slide-rule-python/services/app_store.py
@@ -500,16 +500,35 @@ def save_version(root_id: str, parent_id: str, model: dict[str, Any], *, goal: s
     return get_backend().save(record)
 
 
-def fork_app(source_id: str, *, session_id: Optional[str] = None) -> Optional[str]:
+def fork_app(
+    source_id: str,
+    *,
+    session_id: Optional[str] = None,
+    new_name: Optional[str] = None,
+) -> Optional[str]:
     """从现有应用分出一条新血缘：新 root·v1·parent 指向源，model_json 拷贝一份。
-    源不存在返回 None。用于"以某个生成应用为起点，改成一个新应用"。"""
+    源不存在返回 None。用于"以某个生成应用为起点，改成一个新应用"。
+
+    - new_name：给副本改名（写进模型身份 appIdentity.productName，product_name
+      元数据会自动跟着 re-derive）。对标 Budibase duplicateApp 的"预填 X 副本"——
+      避免复刻出同名孪生卡。
+    - session_id：不再默认继承源应用的会话（那会导致点开副本却进了源会话）。
+      只在显式传入时才带；默认 None = 副本是独立设计快照，不绑任何会话。
+    """
     source = get_backend().get(source_id)
     if source is None:
         return None
+    import copy
+
+    model = copy.deepcopy(source.get("model_json") or {})
+    if new_name and isinstance(model, dict):
+        appbundle = model.setdefault("appbundle", {})
+        identity = appbundle.setdefault("appIdentity", {})
+        identity["productName"] = str(new_name)[:120]
     app_id = _new_id()
     record = _build_record(
-        source.get("model_json") or {}, goal=source.get("goal") or "",
-        session_id=session_id or source.get("session_id"),
+        model, goal=source.get("goal") or "",
+        session_id=session_id,
         gate_passed=bool(source.get("gate_passed")),
         app_id=app_id, root_id=app_id, parent_id=source_id, version=1,
     )

--- a/slide-rule-python/services/app_store.py
+++ b/slide-rule-python/services/app_store.py
@@ -128,6 +128,9 @@ class AppStoreBackend:
     def find_by_dedup_key(self, dedup_key: str) -> Optional[dict[str, Any]]:  # pragma: no cover
         raise NotImplementedError
 
+    def delete(self, app_id: str) -> bool:  # pragma: no cover
+        raise NotImplementedError
+
     def export_all(self) -> list[dict[str, Any]]:  # pragma: no cover
         raise NotImplementedError
 
@@ -202,6 +205,15 @@ class JsonFileAppStore(AppStoreBackend):
                 if r.get("dedup_key") == dedup_key:
                     return r
         return None
+
+    def delete(self, app_id: str) -> bool:
+        with self._lock:
+            rows = self._read()
+            remaining = [r for r in rows if r.get("id") != app_id]
+            if len(remaining) == len(rows):
+                return False
+            self._write(remaining)
+        return True
 
     def export_all(self) -> list[dict[str, Any]]:
         with self._lock:
@@ -380,6 +392,15 @@ def _sqlalchemy_backend(database_url: str) -> AppStoreBackend:
                 ).first()
                 return row.to_record() if row else None
 
+        def delete(self, app_id: str) -> bool:
+            with Session(engine) as s:
+                row = s.get(GeneratedApp, app_id)
+                if row is None:
+                    return False
+                s.delete(row)
+                s.commit()
+            return True
+
         def export_all(self) -> list[dict[str, Any]]:
             with Session(engine) as s:
                 return [r.to_record() for r in s.scalars(select(GeneratedApp))]
@@ -506,6 +527,12 @@ def list_apps(*, limit: int = 50, offset: int = 0, latest_per_root: bool = True)
 
 def list_versions(root_id: str) -> list[dict[str, Any]]:
     return get_backend().versions(root_id)
+
+
+def delete_app(app_id: str) -> bool:
+    """从画廊移除一个应用记录。返回是否真删到（不存在返回 False）。
+    只删这一条记录，不动它对应的推演会话（会话另有独立生命周期）。"""
+    return get_backend().delete(app_id)
 
 
 def export_all() -> list[dict[str, Any]]:

--- a/slide-rule-python/tests/test_app_store.py
+++ b/slide-rule-python/tests/test_app_store.py
@@ -107,6 +107,18 @@ def test_dedup_key_new_record_when_model_changes(configured_store):
     assert len(store.list_apps()) == 2
 
 
+def test_delete_removes_record(configured_store):
+    a = store.save_app(_model("咖营通"), session_id="s1")
+    store.save_app(_model("宠医云"), session_id="s2")
+    assert store.delete_app(a) is True
+    assert store.get_app(a) is None
+    assert len(store.list_apps()) == 1, "删掉一条后列表只剩另一条"
+
+
+def test_delete_missing_returns_false(configured_store):
+    assert store.delete_app("does-not-exist") is False
+
+
 def test_export_all_returns_full_records(configured_store):
     store.save_app(_model("咖营通"))
     store.save_app(_model("宠医云"))

--- a/slide-rule-python/tests/test_app_store.py
+++ b/slide-rule-python/tests/test_app_store.py
@@ -89,6 +89,25 @@ def test_fork_missing_source_returns_none(configured_store):
     assert store.fork_app("nope") is None
 
 
+def test_fork_with_new_name_renames_copy(configured_store):
+    """复刻改名（对标 Budibase）：副本的 productName + product_name 元数据都跟着改，
+    源应用不受影响。"""
+    a = store.save_app(_model("咖营通"), session_id="s1")
+    fk = store.fork_app(a, new_name="奶茶版")
+    rec = store.get_app(fk)
+    assert rec["product_name"] == "奶茶版"
+    assert rec["model_json"]["appbundle"]["appIdentity"]["productName"] == "奶茶版"
+    assert rec["parent_id"] == a and rec["root_id"] == fk, "仍是新血缘、parent 指源"
+    assert store.get_app(a)["product_name"] == "咖营通", "源应用名不受影响"
+
+
+def test_fork_default_does_not_inherit_source_session(configured_store):
+    """默认不继承源会话——避免点开副本却进了源应用的会话。"""
+    a = store.save_app(_model("咖营通"), session_id="s1")
+    fk = store.fork_app(a)  # 不传 session_id
+    assert store.get_app(fk)["session_id"] is None
+
+
 def test_dedup_key_is_idempotent(configured_store):
     model = _model("咖营通")
     sig = store.model_signature("s1", model)


### PR DESCRIPTION
## 概述
把「应用中心」从临时会话库切到 App Store 持久层，并按成熟低代码产品
（Appsmith / ToolJet / Budibase）的画廊做法补齐了一批体验，外加一套
Render 一键部署蓝图。

## 主要改动

### 应用中心画廊（前端）
- **① 数据源正位**：从临时会话库切到 App Store 持久层——闭环应用读 `/apps`
  摘要、完整模型按卡懒拉走活渲染；尚未落库的在推演会话草稿按 `session_id`
  去重合并进来，**零回退**（现有会话卡一张不丢）。取数分层对标 ToolJet
  `apps.service`（getAll 摘要 + getApp 详情 + clone + delete）。
- **② 复刻 / 删除**：卡片菜单「复刻应用」→ 弹框预填「源名 副本」改名（对标
  Budibase `duplicateApp`），`fork_app` 分新血缘、不继承源会话；「删除应用」
  走 `DELETE /apps/{id}`（只删记录不动会话）。卡上 `v>1` 显版本徽标。
- **③ 展会三件套**（对标 ToolJet AppList / BlankPage、moment fromNow）：
  骨架屏（加载态铺等尺寸占位卡）/ 插画空态（首屏附官方示例起手卡）/
  相对时间（「刚刚 / N 分钟前 / 昨天…」，绝对时间做 title 兜底）。

### App Store 持久层（Python）
- 生成应用「设计层」持久化：`save_app / save_version / fork_app / delete /
  list / versions / export`，带血缘（root/parent/version）与幂等去重。
- 双后端一套接口：配 `APP_STORE_DATABASE_URL` 走 SQLAlchemy（Neon/自建
  Postgres，含 PgBouncer 最佳实践：NullPool + 关预处理语句 + 连接超时 + TCP
  探针 fail-open）；不配 fail-open 回退本地 JSON 文件，行为一致、不引入新失败面。
- API：`GET /apps`（摘要列表）`GET /apps/{id}`（完整模型）
  `GET /apps/{root}/versions` `POST /apps/{id}/fork` `DELETE /apps/{id}`
  `GET /apps-export`。

### 部署基建
- `render.yaml` 蓝图：两服务（Node Web + Python）一键部署，接好内部密钥/地址。
- Dockerfile：uvicorn 监听地址可配 `${UVICORN_HOST:-::}`、听平台注入的 `$PORT`
  （兼容 Railway IPv6 私网 / Render / docker-compose）。

## 测试
- 前端：dashboard 23 例（卡片派生 / 合并去重 / 筛选 / 相对时间）；`tsc` 0 error。
- Python：app_store 30 例（JSON + SQLite 两后端参数化，含 fork 改名 / 解耦会话 /
  删除 / Neon 引擎配置）。
- 真机 E2E 截图验证：画廊数据源合并、复刻改名、删除、三态空/骨架/相对时间。

## 兼容 / 风险
- App Store 连不上 DB 时 fail-open 回 JSON 文件，不崩。
- 画廊数据源改动为纯前端 + 一个 DELETE 端点，Node 代理层零改动。
- Dockerfile / 蓝图改动对现有 docker-compose 完全兼容。