### PR TITLE
修 dev:stop 在 Windows 清不掉端口 + dev:all 拒绝启动时静默无输出

### DIFF
--- a/scripts/dev-all.mjs
+++ b/scripts/dev-all.mjs
@@ -574,7 +574,21 @@ async function preflightDevPorts() {
       `If the owner PID is unresolvable in tasklist it is likely a WSL relay — run "wsl --shutdown" ` +
       `(Windows) and retry. To force-start anyway: set DEV_ALL_ALLOW_BUSY_PORTS=1.`
   );
-  process.exit(1);
+  // 不能用 process.exit()：Windows 上 stdout/stderr 走管道是异步写，exit() 不等
+  // 缓冲区刷完就终止进程，上面这条 console.error 会被整条吞掉——真实现场是用户
+  // 只看到 "Ports already occupied…" 然后直接回到提示符，既没启动也没有任何原因，
+  // 完全无从排查。设 exitCode 让事件循环自然退出，消息才保得住。
+  process.exitCode = 1;
+  throw new PreflightAbort(stillLabel);
+}
+
+/** 端口未清干净时中止启动。单独一个类型，好让 main() 区分"预检拒绝"（已经
+ *  打印过原因，静默收场即可）和真异常（需要打印堆栈）。 */
+class PreflightAbort extends Error {
+  constructor(label) {
+    super(`preflight aborted: ports busy (${label})`);
+    this.name = "PreflightAbort";
+  }
 }
 
 async function main() {
@@ -708,5 +722,11 @@ async function main() {
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  void main();
+  main().catch((error) => {
+    // 预检拒绝：原因已经打印过，别再糊一屏堆栈盖住它。其余异常照常抛详情。
+    if (!(error instanceof PreflightAbort)) {
+      console.error(`[dev:all] ${error?.stack || error}`);
+    }
+    process.exitCode = 1;
+  });
 }

--- a/scripts/dev-stop.mjs
+++ b/scripts/dev-stop.mjs
@@ -153,8 +153,16 @@ async function listWindowsListeningPids(port) {
   }
 }
 
-/** tasklist 解析进程名；返回 null = PID 查不到（幽灵：属主已死、端口表未刷新，
- *  或 WSL 端口转发/提权进程）。 */
+/** WSL 的端口转发中继：taskkill 掉它没用（wslhost 会被重新拉起，端口还在
+ *  Linux 侧监听），真正的出路是 wsl --shutdown。单独认出来才能给对的建议。 */
+const WSL_RELAY_NAMES = ["wslrelay", "wslhost", "wslservice", "vmmem", "vmmemwsl"];
+
+/** 解析 PID → 进程名。两级：
+ *  1. tasklist（快）
+ *  2. CIM 兜底——tasklist 的 /FI 过滤器在跨会话/提权进程上会查不到，而
+ *     Get-CimInstance 通常还能返回。真实事故：9700 的属主 tasklist 报
+ *     "查不到"，于是 sweep 直接放弃，端口永远清不掉。
+ *  返回 null = 两条路都查不到（进程确实已消失，或权限完全不够）。 */
 async function resolveWindowsProcessName(pid) {
   try {
     const { stdout } = await execFileAsync(
@@ -163,7 +171,23 @@ async function resolveWindowsProcessName(pid) {
       { cwd: projectRoot }
     );
     const m = stdout.match(/^"([^"]+)"/m);
-    return m ? m[1] : null;
+    if (m) return m[1];
+  } catch {
+    /* 落到 CIM 兜底 */
+  }
+  try {
+    const { stdout } = await execFileAsync(
+      "powershell.exe",
+      [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `(Get-CimInstance Win32_Process -Filter "ProcessId=${Number(pid)}" -ErrorAction SilentlyContinue).Name`,
+      ],
+      { cwd: projectRoot }
+    );
+    const name = stdout.trim();
+    return name || null;
   } catch {
     return null;
   }
@@ -176,18 +200,43 @@ async function sweepWindowsDevPorts() {
       if (pid === process.pid) continue;
       const name = await resolveWindowsProcessName(pid);
       if (name === null) {
-        // 幽灵 PID：真实事故里这是"已退出的父进程"——监听套接字被它 spawn 的
-        // 子进程继承着，端口表还挂着死父 PID。真正的持有者（孤儿 python worker）
-        // 由 stopWindowsProjectProcesses 的可执行路径匹配 + 后代闭包负责收掉，
-        // 这里只把真相喊出来，最后统一复查端口是否解放。
+        // 幽灵 PID：属主已退出但监听套接字被它 spawn 的子进程继承着，端口表
+        // 还挂着死父 PID。
+        //
+        // 此前这里只打印一行就 continue，从不尝试 taskkill——真实事故：用户
+        // 反复 dev:stop，每次都看到 "UNRESOLVABLE"，端口永远清不掉，dev:all
+        // 也就永远起不来。查不到名字 ≠ 杀不掉：tasklist 的过滤器与 taskkill
+        // 走的是不同路径，权限也未必相同。这里改成照杀。
+        //
+        // 敢杀的依据：DEV_PORTS 是本项目自己的端口，且此刻 project-process
+        // 清扫已经跑完（真正属于别人的进程会在下面按名字被认出来并放行）。
         console.log(
-          `Port ${port} owner PID ${pid} is UNRESOLVABLE (dead parent with orphaned child, ` +
-            `WSL relay, or elevated process). Orphan cleanup already ran; re-checking below.`
+          `Port ${port} owner PID ${pid} is unresolvable by name (dead parent with orphaned ` +
+            `child, or elevated/cross-session process) — attempting kill anyway.`
+        );
+        sawGhost = true;
+        try {
+          await execFileAsync("taskkill", ["/PID", String(pid), "/T", "/F"], { cwd: projectRoot });
+          console.log(`Stopped unresolvable PID ${pid} tree (port ${port})`);
+        } catch (error) {
+          console.warn(
+            `[dev:stop] taskkill PID ${pid} (port ${port}) failed: ${error?.message ?? error}`
+          );
+        }
+        continue;
+      }
+      const base = name.toLowerCase().replace(/\.exe$/, "");
+      if (WSL_RELAY_NAMES.includes(base)) {
+        // WSL 端口转发：端口实际在 Linux 侧监听，杀掉 Windows 这边的中继没用
+        // （wslhost 会被重新拉起）。说清楚，别让用户以为 dev:stop 失灵了。
+        console.warn(
+          `[dev:stop] Port ${port} is held by WSL port-forward relay ${name} (PID ${pid}). ` +
+            `taskkill won't free it — the listener lives inside WSL. Stop the process in your ` +
+            `WSL shell, or run "wsl --shutdown" from Windows, then retry.`
         );
         sawGhost = true;
         continue;
       }
-      const base = name.toLowerCase().replace(/\.exe$/, "");
       if (DEV_PROCESS_NAMES.includes(base)) {
         // /T 连子进程树一起收：父进程单杀会把继承了套接字的子进程留成下一个幽灵
         try {


### PR DESCRIPTION
真实现场（Windows）：
    Port 9700 owner PID 20288 is UNRESOLVABLE ...
    [dev:stop] !!! Port 9700 is STILL occupied after cleanup (PID 20288)
    dev:stop complete.
反复 dev:stop 都是这几行，端口永远清不掉；接着 npm run dev:all 打完
"Ports already occupied…" 就直接回到提示符，既没启动也没有任何原因。

三个独立的 bug：

一、dev:stop 对查不到名字的 PID 从不尝试 kill（根因）
sweepWindowsDevPorts 里 resolveWindowsProcessName 返回 null 就只打印一行
然后 continue——一次 taskkill 都没发过。注释说真正的持有者由
stopWindowsProjectProcesses 按可执行路径兜底收掉，但那一路的候选集先按进程名
过滤（node/npm/cmd/python*），孤儿或跨会话进程根本进不了候选集，所以那边报
"No project dev processes found"，两条路都不管，端口就此卡死。
改为：查不到名字也照发 taskkill /T /F。查不到 ≠ 杀不掉——tasklist 的 /FI
过滤器与 taskkill 走的不是同一条路径，权限也未必相同。敢杀的依据是
DEV_PORTS 是本项目自己的端口，且此时项目进程清扫已经跑完（真属于别人的进程
会在下面按名字被认出来并放行，行为不变）。

二、PID 解析只有 tasklist 一条路
tasklist 的 /FI 过滤器在跨会话/提权进程上会查不到，而 Get-CimInstance
Win32_Process 通常还能返回。加 CIM 兜底，把"幽灵"缩小到真正查不到的那些。

三、WSL 端口转发被混在"幽灵"里
端口实际在 Linux 侧监听时，Windows 这边是 wslrelay/wslhost 之类的中继，
taskkill 掉没用（会被重新拉起）。单独认出来并给出正确出路（在 WSL 里停进程，
或 wsl --shutdown），不再让用户以为是 dev:stop 失灵。

四、dev:all 拒绝启动时 console.error 被吞
preflightDevPorts 在端口没清干净时 console.error(原因) 后紧跟 process.exit(1)。
Node 的 stdout/stderr 走管道是异步写，exit() 不等缓冲刷完就终止进程，这条消息
整条丢失——用户只看到"Ports already occupied…"然后回到提示符，完全无从排查。
实测（Linux 管道，Windows 更严重）：
    console.error(200000 字节) + process.exit(1)      → 实际只出 65536 字节
    console.error(200000 字节) + process.exitCode = 1 → 完整 200001 字节
改为设 exitCode + 抛 PreflightAbort，由入口的 catch 静默收场（原因已打印过，
不再糊一屏堆栈盖住它）；其余异常照常打印详情。顺带把 void main() 换成带
catch 的调用，避免未处理拒绝。

验证（Linux 侧可测的部分）：
- 端口被非 dev 进程占住时 dev:all 退出码 1，拒绝原因完整打印、无堆栈噪音
- 端口空闲时正常启动，不受影响
- 两个脚本 node --check 通过；node --run check 干净
Windows 分支（taskkill/tasklist/CIM/WSL 中继）无法在本机验证，需要在
Windows 上复跑一次确认。