### PR TITLE
线上事故三修：Neon 初始化堵死 / 推演阻塞事件循环 / 缩略图 PNG→WebP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -138,6 +138,22 @@ SESSION_SECRET=replace_with_a_64_char_random_hex_secret
 # ⚠️ 从第 3 级开始数据与远端分叉：远端恢复后本地这段时间的记录不会自动回流，
 # 需要人工导出/合并。降级时日志会打印"现在写在哪"。
 #
+# 直接走 Neon SQL over HTTP，跳过 TCP（默认关，2026-08-02 事故后加）。
+#
+# 什么时候需要它：TCP **能连上、但是慢**的环境。上面那套降级只在 TCP
+# 抛异常时才轮到 HTTP，而"慢"不抛异常，于是永远走不到——线上就是这么被堵死的。
+#
+# 两条通道实测（同一个库同一份数据）：
+#   TCP   Neon pooler 解析出 6 个地址（3 IPv4 + 3 IPv6），psycopg 逐个试、
+#         每个 connect_timeout=4s，最坏单次连接 24s。
+#   HTTP  共享 httpx 连接（keep-alive）、每次查询 15s 硬超时，不会卡住不返回。
+#         实测 p50 77ms（= 网络往返）、并发 8 吞吐 31 条/s；11 个存储接口方法
+#         全部自实现，与 SQLAlchemy 后端功能逐项对齐（含版本链/继承/删除）。
+#
+# 只对 *.neon.tech 生效；自建 PG/RDS 没有这个端点，设了会被忽略。
+# 它自己连不上时照旧继续往下降级（SQLite → JSON）。
+# APP_STORE_NEON_HTTP=false
+
 # 本地 SQLite 档的路径（默认如下）。置空则跳过这一级、直接用 JSON——
 # 只读文件系统或不想在磁盘上留库文件时用得上：
 # APP_STORE_LOCAL_SQLITE=sqlite:///data/sliderule-apps.db

--- a/client/src/lib/thumb-capture.ts
+++ b/client/src/lib/thumb-capture.ts
@@ -99,8 +99,30 @@ function cropToAspect(
   return out;
 }
 
+/**
+ * WebP 编码质量。与服务端 thumb_image.WEBP_QUALITY 保持一致（0~1 vs 0~100）。
+ *
+ * 参照：Next.js Image 默认 75、thumbor 默认 80、imgproxy 默认 80。取 0.82 是
+ * 因为这些是**界面截图**——大片纯色加细字，比照片更吃量化噪声，稍高一档更稳。
+ */
+const WEBP_QUALITY = 0.82;
+
+/**
+ * 采出来的画面编码成 blob。
+ *
+ * **直接出 WebP，不出 PNG**（2026-08-02）。实测同样分辨率下 805KB PNG →
+ * 43KB WebP，小 19 倍，而分辨率一个像素不减。这条省的是两段流量：回传时的
+ * 上行，以及之后每个访客看这张卡的下行（后者才是大头——应用中心一次首屏
+ * 23 张卡，10.7MB → 约 0.9MB）。
+ *
+ * 服务端也会再压一次（thumb_image.to_webp），那是给参照板那一路和历史存量用的；
+ * 已经是 WebP 的它会原样放行，不会重复编码掉画质。
+ *
+ * canvas.toBlob 对不认识的 type 会**静默回落成 PNG**（规范如此），所以这里
+ * 显式检查一次实际拿到的类型——回落了就如实按 PNG 走，不假装省了带宽。
+ */
 function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob | null> {
-  return new Promise(resolve => canvas.toBlob(resolve, "image/png"));
+  return new Promise(resolve => canvas.toBlob(resolve, "image/webp", WEBP_QUALITY));
 }
 
 /** 浏览器空闲时再动手——采集是给缩略图用的，永远排在用户交互后面。 */
@@ -164,7 +186,8 @@ export function captureAndUpload(req: CaptureRequest): Promise<boolean> {
 
       const res = await fetch(`/api/sliderule/apps/${encodeURIComponent(appId)}/preview`, {
         method: "POST",
-        headers: { "Content-Type": "image/png" },
+        // 按 blob 实际类型报，不写死——toBlob 不认 webp 时会静默回落成 PNG。
+        headers: { "Content-Type": blob.type || "image/webp" },
         body: blob,
       });
       if (!res.ok) return false;

--- a/slide-rule-python/Dockerfile
+++ b/slide-rule-python/Dockerfile
@@ -36,4 +36,10 @@ EXPOSE 9700
 # IPv4 连接 → 健康检查超时。这类平台把 UVICORN_HOST 设成 0.0.0.0 即可。
 # 端口听平台注入的 $PORT，没有回落 9700（compose 设了 PORT=9700）。
 # sh -c + exec 保证 uvicorn 是 PID 1、正常收 SIGTERM 优雅退出。
-CMD ["sh", "-c", "exec python -m uvicorn app:app --host ${UVICORN_HOST:-::} --port ${PORT:-9700}"]
+#
+# --timeout-graceful-shutdown：收到 SIGTERM 后最多等在途请求这么久，然后强退
+# （2026-08-02 事故后加）。默认是**无限等**——而一趟推演要 6~20 分钟，于是
+# 容器停不下来：实测本地 dev:stop 停不掉、端口一直被占，只能手动 kill 端口
+# 占用进程。部署时这表现为滚动更新卡住。30s 够让正常请求收尾，又不会被一趟
+# 长推演拖住。
+CMD ["sh", "-c", "exec python -m uvicorn app:app --host ${UVICORN_HOST:-::} --port ${PORT:-9700} --timeout-graceful-shutdown ${UVICORN_GRACEFUL_TIMEOUT:-30}"]

--- a/slide-rule-python/requirements.txt
+++ b/slide-rule-python/requirements.txt
@@ -34,3 +34,8 @@ psycopg[binary]>=3.2
 
 # P2b execution tools: code.run runs ONLY inside E2B sandbox (fail-closed without key)
 e2b-code-interpreter>=2.8.0
+
+# 缩略图编码（2026-08-02）：卡片缩略图从 PNG 换 WebP，实测 805KB → 43KB
+# （分辨率不减）。见 services/thumb_image.py。
+# 惰性导入 + fail-open：装不上时整条压缩链路静默失效、原样存 PNG，不影响功能。
+pillow>=10.4

--- a/slide-rule-python/routes/sliderule_full.py
+++ b/slide-rule-python/routes/sliderule_full.py
@@ -585,7 +585,9 @@ async def exec_cap(payload: Dict[str, Any], x_internal_key: Optional[str] = Head
     return result
 
 @router.post("/drive-turn")
-async def drive(payload: Dict[str, Any], x_internal_key: Optional[str] = Header(None)):
+# `def` 而不是 `async def`——理由与 /drive-full 那条完全相同（见下面那段长注释）：
+# drive_reasoning_turn 是同步的重活，写在 async 里会占住事件循环。
+def drive(payload: Dict[str, Any], x_internal_key: Optional[str] = Header(None)):
     """Single turn drive (drive_reasoning_turn). Full multi-loop driver authority exposed via /drive-full."""
     _auth(x_internal_key)
     state = V5SessionState(**payload["state"])
@@ -594,7 +596,29 @@ async def drive(payload: Dict[str, Any], x_internal_key: Optional[str] = Header(
     return {"state": new_state.model_dump(), "stateAuthority": STATE_AUTHORITY_PYTHON, "provenance": PROVENANCE_PYTHON_RAG, "backend": PYTHON_BACKEND}
 
 @router.post("/drive-full")
-async def drive_full(payload: Dict[str, Any], x_internal_key: Optional[str] = Header(None)):
+# ⚠️ 这条路由是 `def` 而不是 `async def`——**故意的，别改回去**（2026-08-02）。
+#
+# 事故形状：只要有人在推演，整个服务就不响应，连 /api/health 都超时。原因是
+# drive_full_v5_session 是**同步**函数（v5_full_driver.py），一趟推演 6~20 分钟
+# （实测本次 5 个话题 374~1190s），此前它被直接写在 `async def` 里，于是整段
+# 跑在事件循环那条线程上——单 worker 下，事件循环被占住 = 全站失联。
+#
+# 修法用的是 FastAPI 官方口径，不是自己发明的：
+#   "When you declare a path operation function with normal `def` instead of
+#    `async def`, it is run in an external threadpool that is then awaited,
+#    instead of being called directly (as it would block the server)."
+#   —— fastapi.tiangolo.com/async/
+# 底层是 Starlette 的 run_in_threadpool → anyio.to_thread.run_sync。
+#
+# 为什么不用 asyncio.to_thread 手动包一层：能达到同样效果，但要在每个调用点
+# 各写一遍、且容易漏（本文件里 LLM/RAG 那几条就是这么写的，而这两条当初正是
+# 漏掉的）。函数签名去掉 async 是**声明式**的，漏不掉。
+#
+# 代价（记下来，别踩）：线程池默认只有 40 个槽（anyio 的
+# current_default_thread_limiter），而每趟推演会占住一个槽十几分钟。同时在跑的
+# 推演超过 40 个就会开始排队——真到那一天，正确的解法是把推演挪进任务队列，
+# 而不是把这个数字调大。
+def drive_full(payload: Dict[str, Any], x_internal_key: Optional[str] = Header(None)):
     """Python driver authority for multiple capability loops until stop condition (coverage/empty picks/max_loops).
     Wires drive_full_v5_session as the visible full-path multi-loop API (PYTHON_AUTHORITY).
     Real userText (user instruction) is forwarded so it drives pick/orchestrate/execute/artifacts/GCOV/phase.

--- a/slide-rule-python/routes/sliderule_full.py
+++ b/slide-rule-python/routes/sliderule_full.py
@@ -1492,6 +1492,7 @@ async def get_generated_app(app_id: str, x_internal_key: Optional[str] = Header(
 @router.get("/apps/{app_id}/preview")
 async def get_generated_app_preview(
     app_id: str,
+    request: Request,
     source: Optional[str] = None,
     x_internal_key: Optional[str] = Header(None),
 ):
@@ -1519,16 +1520,29 @@ async def get_generated_app_preview(
     from services import app_store
 
     # 同步库调用走 to_thread，理由见 list_generated_apps。
-    png = await asyncio.to_thread(
+    data = await asyncio.to_thread(
         app_store.get_app_preview_png,
         app_id,
         source=app_store.normalize_preview_source(source) if source else None,
     )
-    if not png:
+    if not data:
         raise HTTPException(404, "preview not found")
+
+    from services.thumb_image import client_accepts_webp, sniff_media_type, to_png
+
+    # 按内容报 Content-Type，不写死 image/png：库里存量是 PNG、新写入是 WebP，
+    # 报错类型浏览器可能拒绝渲染，CDN 也会缓存错。
+    media = sniff_media_type(data)
+    # Accept 头协商（thumbor / imgproxy / Next.js Image 同款做法）：不认 WebP 的
+    # 客户端现场转回 PNG。WebP 覆盖率 97%+，这条是给极老客户端和抓取工具留的，
+    # 不是主路径。转不动就原样给——宁可让客户端拿到一张它可能不认的图，
+    # 也不要 500。
+    if media == "image/webp" and not client_accepts_webp(request.headers.get("accept")):
+        data = await asyncio.to_thread(to_png, data)
+        media = sniff_media_type(data)
     return Response(
-        content=png,
-        media_type="image/png",
+        content=data,
+        media_type=media,
         headers={"Cache-Control": "public, max-age=31536000, immutable"},
     )
 
@@ -1538,9 +1552,22 @@ async def get_generated_app_preview(
 #: 这是一张缩略图，几 MB 的东西进来只会把列表接口和 Neon 拖慢。
 _MAX_SHOT_BYTES = 3 * 1024 * 1024
 
-#: PNG 的魔数。只认 PNG：取图路由是按 image/png 回的，别的格式进来会让
-#: 浏览器拿到一个声称是 PNG 的 JPEG。
-_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+#: 允许回传的图片格式。采集端出的是 WebP（见 client/src/lib/thumb-capture.ts），
+#: 但 canvas.toBlob 对不认识的 type 会静默回落成 PNG，所以两种都得收。
+#: 仍然只收这两种：取图路由按内容嗅探报 Content-Type，收进来一个声称是图片的
+#: 任意字节流只会让浏览器拿到一张渲染不出来的东西。
+_ALLOWED_SHOT_MAGIC = ("image/png", "image/webp")
+
+
+def _looks_like_image(data: bytes) -> bool:
+    """真的按魔数验一遍。
+
+    sniff_media_type 认不出时会**兜底返回 image/png**（为了让历史存量能正常
+    显示），所以它不能单独用来做入口校验——不然任意字节流都会被判成 PNG 放进来。
+    """
+    return data.startswith(b"\x89PNG\r\n\x1a\n") or (
+        data[:4] == b"RIFF" and data[8:12] == b"WEBP"
+    )
 
 
 @router.post("/apps/{app_id}/preview")
@@ -1585,8 +1612,10 @@ async def upload_generated_app_shot(
         raise HTTPException(400, "empty body")
     if len(body) > _MAX_SHOT_BYTES:
         raise HTTPException(413, "screenshot too large")
-    if not body.startswith(_PNG_MAGIC):
-        raise HTTPException(415, "expected a PNG")
+    from services.thumb_image import sniff_media_type
+
+    if sniff_media_type(body) not in _ALLOWED_SHOT_MAGIC or not _looks_like_image(body):
+        raise HTTPException(415, "expected a PNG or WebP image")
 
     stored = await asyncio.to_thread(app_store.save_app_shot, app_id, body)
     return {"stored": stored, "bytes": len(body)}

--- a/slide-rule-python/routes/sliderule_full.py
+++ b/slide-rule-python/routes/sliderule_full.py
@@ -1432,20 +1432,34 @@ async def list_generated_apps(
     offset: int = 0,
     x_internal_key: Optional[str] = Header(None),
 ):
-    """应用画廊列表——默认每个应用只出最新版，摘要不含大模型载荷。"""
+    """应用画廊列表——默认每个应用只出最新版，摘要不含大模型载荷。
+
+    **同步的库调用必须 to_thread**（2026-08-02 线上事故修复）。这几条路由是
+    `async def`，而 uvicorn 只跑一个 worker、一个事件循环；直接在协程里调同步
+    的 SQLAlchemy，一次慢查询就把整个事件循环冻住——`/api/health` 与
+    `/api/agent-loop/health` 跟着一起超时，"存储层拖垮主链路"的承诺当场作废。
+    这正是切回 Neon 后线上观察到的形状。
+
+    本文件里 LLM/RAG/附件解析那几条早就是这么写的（见 asyncio.to_thread 的
+    其它调用点），app store 这几条是漏网的。
+    """
     _auth(x_internal_key)
     from services import app_store
 
-    return {"apps": app_store.list_apps(limit=limit, offset=offset)}
+    apps = await asyncio.to_thread(app_store.list_apps, limit=limit, offset=offset)
+    return {"apps": apps}
 
 
 @router.get("/apps/{app_id}")
 async def get_generated_app(app_id: str, x_internal_key: Optional[str] = Header(None)):
-    """取一个生成应用的完整记录（含 model_json，可直接重开渲染）。"""
+    """取一个生成应用的完整记录（含 model_json，可直接重开渲染）。
+
+    同步库调用走 to_thread，理由见 list_generated_apps。
+    """
     _auth(x_internal_key)
     from services import app_store
 
-    record = app_store.get_app(app_id)
+    record = await asyncio.to_thread(app_store.get_app, app_id)
     if record is None:
         raise HTTPException(404, "app not found")
     return record
@@ -1480,8 +1494,11 @@ async def get_generated_app_preview(
     _auth(x_internal_key)
     from services import app_store
 
-    png = app_store.get_app_preview_png(
-        app_id, source=app_store.normalize_preview_source(source) if source else None
+    # 同步库调用走 to_thread，理由见 list_generated_apps。
+    png = await asyncio.to_thread(
+        app_store.get_app_preview_png,
+        app_id,
+        source=app_store.normalize_preview_source(source) if source else None,
     )
     if not png:
         raise HTTPException(404, "preview not found")
@@ -1533,9 +1550,10 @@ async def upload_generated_app_shot(
     _auth(x_internal_key)
     from services import app_store
 
-    if app_store.get_app(app_id) is None:
+    # 同步库调用走 to_thread，理由见 list_generated_apps。
+    if await asyncio.to_thread(app_store.get_app, app_id) is None:
         raise HTTPException(404, "app not found")
-    if app_store.app_has_shot(app_id):
+    if await asyncio.to_thread(app_store.app_has_shot, app_id):
         return {"stored": False, "reason": "already_has_shot"}
 
     body = await request.body()
@@ -1546,7 +1564,7 @@ async def upload_generated_app_shot(
     if not body.startswith(_PNG_MAGIC):
         raise HTTPException(415, "expected a PNG")
 
-    stored = app_store.save_app_shot(app_id, body)
+    stored = await asyncio.to_thread(app_store.save_app_shot, app_id, body)
     return {"stored": stored, "bytes": len(body)}
 
 
@@ -1556,7 +1574,8 @@ async def list_generated_app_versions(root_id: str, x_internal_key: Optional[str
     _auth(x_internal_key)
     from services import app_store
 
-    return {"versions": app_store.list_versions(root_id)}
+    versions = await asyncio.to_thread(app_store.list_versions, root_id)
+    return {"versions": versions}
 
 
 @router.post("/apps/{app_id}/fork")

--- a/slide-rule-python/scripts/thumb_recompress.py
+++ b/slide-rule-python/scripts/thumb_recompress.py
@@ -1,0 +1,109 @@
+"""把库里存量的 PNG 缩略图重新编码成 WebP（2026-08-02）。
+
+新写入的缩略图已经是 WebP（services/thumb_image），但改动之前落的那些还是 PNG，
+每张 805~857KB。这个脚本把它们就地换掉——**分辨率不动，只换编码**。
+
+    cd slide-rule-python
+    .venv/bin/python scripts/thumb_recompress.py --dry-run   # 只看能省多少
+    .venv/bin/python scripts/thumb_recompress.py             # 真写
+
+--dry-run 是默认关的反面：默认**只看不写**，要加 --apply 才真改。缩略图是线上
+数据，误跑一次没有回头路（原始 PNG 不会另存一份）。
+
+顺带：这个脚本的输出就是压缩比的实测依据。单测里**不**断言压缩比——合成夹具
+造不出真实缩略图那种体积，在它上面断言比例是自欺欺人（见 tests/test_thumb_image
+里那段说明）。
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import sys
+from pathlib import Path
+
+_PY_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PY_DIR))
+
+
+def _load_env() -> None:
+    """按 .env 配好存储后端——脚本跟服务读同一份配置。"""
+    import os
+
+    for path in (_PY_DIR.parent / ".env", _PY_DIR / ".env"):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for line in text.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            os.environ.setdefault(k.strip(), v.strip())
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--apply", action="store_true", help="真的写回去（默认只看不写）")
+    ap.add_argument("--limit", type=int, default=0, help="只处理前 N 条（调试用）")
+    args = ap.parse_args()
+
+    _load_env()
+    from services import app_store as store
+    from services.thumb_image import sniff_media_type, to_webp
+
+    backend = store.get_backend()
+    tags = backend.preview_sources()
+    ids = sorted(tags)
+    if args.limit:
+        ids = ids[: args.limit]
+    if not ids:
+        print("库里没有缩略图，无事可做")
+        return 0
+
+    print(f"{'app_id':<10}{'来源':<7}{'原始':>10}{'WebP':>10}{'倍数':>7}")
+    total_before = total_after = 0
+    changed = 0
+    for app_id in ids:
+        for src in store.PREVIEW_SOURCE_PRIORITY:
+            b64 = backend.get_preview(app_id, source=src)
+            if not b64:
+                continue
+            raw = base64.b64decode(b64)
+            if sniff_media_type(raw) == "image/webp":
+                continue  # 已经换过了
+            out = to_webp(raw)
+            total_before += len(raw)
+            total_after += len(out)
+            ratio = len(raw) / max(1, len(out))
+            print(
+                f"{app_id[:8]:<10}{src:<7}{len(raw)//1024:>8}KB{len(out)//1024:>8}KB"
+                f"{ratio:>6.1f}x"
+            )
+            if args.apply and len(out) < len(raw):
+                backend.save_preview(
+                    app_id, base64.b64encode(out).decode("ascii"), source=src
+                )
+                changed += 1
+
+    if total_before == 0:
+        print("\n所有缩略图都已经是 WebP，无事可做")
+        return 0
+    mb = lambda n: n / 1024 / 1024  # noqa: E731
+    print(
+        f"\n合计 {mb(total_before):.1f}MB → {mb(total_after):.1f}MB"
+        f"（小 {total_before / max(1, total_after):.1f} 倍）"
+    )
+    # 5Mbps = 640KB/s，应用中心首屏要把所有卡的图都拉一遍
+    for label, n in (("改前", total_before), ("改后", total_after)):
+        print(f"  {label}：5Mbps 出口上冷启动一次 ≈ {n / 1024 / 640:.1f}s")
+    if args.apply:
+        print(f"\n已写回 {changed} 张")
+    else:
+        print("\n（--dry-run 模式，什么都没写。要真改加 --apply）")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/slide-rule-python/services/app_store.py
+++ b/slide-rule-python/services/app_store.py
@@ -39,6 +39,33 @@ from typing import Any, Optional
 from config.settings import settings
 
 
+# ── Postgres 服务端超时与初始化预算（2026-08-02 线上事故修复）───────────
+#
+# 事故：切回 Neon 后 Python 单 worker 被堵死，/api/health 一起超时。这一组值
+# 是为了让"卡住"变成"抛异常"——下面那套四级 fail-open 全靠 except 触发，而一条
+# 永远不返回的查询什么都不抛，于是一级都不会降。
+
+#: 单条语句上限。正常查询是百毫秒级（最大的一次是取一张几百 KB 的缩略图），
+#: 8s 只用来兜"不正常"，不会误伤。
+_PG_STATEMENT_TIMEOUT_MS = 8_000
+#: 等锁上限。专门给 DDL——ALTER TABLE 要 ACCESS EXCLUSIVE 锁，撞上任何一个
+#: 正在读这张表的连接就会**无限等**。3s 等不到就放弃，下次启动再补。
+_PG_LOCK_TIMEOUT_MS = 3_000
+#: 事务里发呆多久自己断。防的是"连接攥着锁不放，把别人全堵住"。
+_PG_IDLE_TX_TIMEOUT_MS = 10_000
+
+#: 整个远端后端初始化的墙钟预算，超了就当这一级不可用、降到下一级。
+#:
+#: **这是最后一道防线，也是唯一不依赖库配合的一道**：上面三个超时要连上库、
+#: 且服务端认 options 才生效；连接串自带 options（Neon 用它做端点路由）时它们
+#: 压根不会被设上。而初始化本身可能在任何一步慢下来——多地址逐个重试、pooler
+#: 冷启动、驱动类型初始化。这条是纯墙钟，谁都拦得住。
+#:
+#: 12s 的来历：连接握手上限 4s，初始化里最多两次连接（见 _sqlalchemy_backend
+#: 已经合并成一次），留一倍余量给建表与补列。
+_SQL_INIT_BUDGET_S = 12.0
+
+
 # ────────────────────────── 缩略图来源 ──────────────────────────
 #
 # 优先级链，靠前的更可信（完整说明见 AppStoreBackend 的缩略图小节）：
@@ -453,17 +480,100 @@ def _sql_engine_config(url: str, null_pool: Any) -> tuple[dict[str, Any], dict[s
       连接池（两层打架 + 长连遇 scale-to-zero 挂起变陈旧）。NullPool 每次开新
       连接、用完即还给 PgBouncer，是 SQLAlchemy 官方对"外部池"的推荐。
     - connect_timeout=4：连不上快速失败 → fail-open 回退 JSON。
+    - options 里的三个服务端超时（2026-08-02 事故修复，见下）。
+
+    ## 为什么必须有语句级超时
+
+    线上事故：切回 Neon 后 Python 单 worker 被堵死，`/api/health` 一起超时。
+    根因之一是**这套四级 fail-open 只兜异常、不兜"卡住"**——降级全靠 except
+    触发，而一条永远不返回的查询什么都不抛，于是一级都不会降。
+
+    `connect_timeout` 只管握手那一段；连上之后想跑多久跑多久。三个服务端超时
+    补的正是这一段：
+
+      statement_timeout                     单条语句上限
+      lock_timeout                          等锁上限——DDL（ALTER TABLE 要
+                                            ACCESS EXCLUSIVE）撞上别的连接时
+                                            会无限等，这条是专门给它的
+      idle_in_transaction_session_timeout   事务里发呆的连接自己断，别攥着锁
+
+    值取得比正常查询宽一个数量级（缩略图那张图几百 KB，正常也就百毫秒级），
+    只用来兜"不正常"。超时表现为异常 → 上层照常降级到下一级存储，而不是吊死。
+
+    ⚠️ 连接串自带 options 时**不覆盖**：Neon 用 `options=endpoint%3D...` 做
+    端点路由，盖掉会连错库。这种情况下放弃设超时（宁可没有，也不能改坏路由），
+    由 get_backend 的墙钟预算兜底。
     """
     connect_args: dict[str, Any] = {}
     engine_kwargs: dict[str, Any] = {"future": True}
     if url.startswith("postgresql"):
         connect_args["connect_timeout"] = 4
         connect_args["prepare_threshold"] = None
+        if "options=" not in url:
+            connect_args["options"] = (
+                f"-c statement_timeout={_PG_STATEMENT_TIMEOUT_MS}"
+                f" -c lock_timeout={_PG_LOCK_TIMEOUT_MS}"
+                f" -c idle_in_transaction_session_timeout={_PG_IDLE_TX_TIMEOUT_MS}"
+            )
         engine_kwargs["poolclass"] = null_pool
     else:
         # 本地 SQLite：无外部池，保留 pre_ping（文件库无 scale-to-zero 问题，无害）。
         engine_kwargs["pool_pre_ping"] = True
     return connect_args, engine_kwargs
+
+
+def _sqlalchemy_backend_within_budget(database_url: str) -> AppStoreBackend:
+    """给远端后端的初始化套一个墙钟预算（2026-08-02 线上事故修复）。
+
+    ## 为什么需要它
+
+    事故形状：切回 Neon 后 Python 单 worker 被堵死，`/api/health` 一起超时。
+    `get_backend` 那套四级 fail-open 全靠 `except` 触发，而**卡住不抛异常**，
+    于是一级都不会降——存储层最终还是把主链路吊死了，正是它承诺绝不做的事。
+
+    服务端超时（statement/lock/idle_in_transaction）能兜住大部分，但它们有个
+    前提：得先连上库、且服务端认 options。连接串自带 options 时（Neon 用它做
+    端点路由，不能覆盖）它们压根设不上；初始化也可能慢在连接之前——多地址逐个
+    重试、pooler 冷启动、驱动类型初始化。这条是纯墙钟，不依赖库配合。
+
+    ## 为什么是"丢弃"而不是"杀掉"
+
+    Python 杀不掉一个正在阻塞的线程。所以超预算时不去杀它，而是**放弃等待、
+    把结果丢掉**，主流程照常降级到下一级存储。被丢下的那个线程自己会结束
+    （每次连接握手有 connect_timeout=4 封顶，工作量是有界的），它只是白干一场。
+
+    这样做是安全的，因为 `_sqlalchemy_backend` 是**纯工厂**：只返回值、不写
+    任何模块级状态。晚到的结果没有任何地方可以污染。
+
+    ## 必须是 daemon 线程，不能用 ThreadPoolExecutor
+
+    第一版用的是 ThreadPoolExecutor + future.result(timeout=…)，**写完就被自己
+    的测试抓了**：它的工作线程是非守护线程，而 concurrent.futures 注册了一个
+    atexit 钩子去 join 它们。于是卡住的初始化线程会挡住**进程退出**——等于把
+    "启动卡死"换成了"关停卡死"，部署时更难受（容器停不下来）。
+
+    daemon 线程没有这个问题：解释器退出时直接丢下它，不 join。
+    """
+    import threading as _threading
+
+    box: dict[str, Any] = {}
+
+    def _run() -> None:
+        try:
+            box["value"] = _sqlalchemy_backend(database_url)
+        except BaseException as exc:  # noqa: BLE001 — 原样带回主线程再抛
+            box["error"] = exc
+
+    worker = _threading.Thread(target=_run, name="appstore-init", daemon=True)
+    worker.start()
+    worker.join(_SQL_INIT_BUDGET_S)
+    if worker.is_alive():
+        raise TimeoutError(
+            f"远端后端初始化超过 {_SQL_INIT_BUDGET_S:g}s 预算，按不可用处理"
+        )
+    if "error" in box:
+        raise box["error"]
+    return box["value"]
 
 
 def _sqlalchemy_backend(database_url: str) -> AppStoreBackend:
@@ -573,7 +683,16 @@ def _sqlalchemy_backend(database_url: str) -> AppStoreBackend:
             finally:
                 probe.close()
     engine = create_engine(url, connect_args=connect_args, **engine_kwargs)
-    Base.metadata.create_all(engine)
+    # 建表 + 补列**共用一条连接**（2026-08-02 事故修复）。
+    #
+    # 原来是 create_all(engine) 一条、inspect(engine) 又一条、ALTER 再一条——
+    # NullPool 下每次都是**新建连接**。平时无所谓（几十毫秒），但线上撞到的正是
+    # "每次连接都慢"：Neon pooler 解析出多个地址、psycopg 逐个试、每个
+    # connect_timeout=4s。连接次数在这条路径上是直接乘上去的成本。
+    #
+    # 合并之后整个初始化只握手一次。
+    with engine.begin() as _init_conn:
+        Base.metadata.create_all(_init_conn)
 
     # create_all **只建不改**：表已经存在时它一列都不会补。generated_app_preview
     # 在生产 Neon 与本地 SQLite 里都早有数据，shot_png_b64 这个新列必须自己
@@ -588,18 +707,25 @@ def _sqlalchemy_backend(database_url: str) -> AppStoreBackend:
     # 带这一列"时那句多余的 ALTER。
     #
     # fail-open：补不上就当没有这个来源——读到 None、等同没图，回落 sheet。
-    try:
-        from sqlalchemy import inspect as _sql_inspect, text as _sql_text
+    #
+    # 跑在上面那条 _init_conn 里，不再另开连接（理由见 create_all 那段）。
+    # 等锁上限由 lock_timeout 兜（见 _PG_LOCK_TIMEOUT_MS）：ALTER 要
+    # ACCESS EXCLUSIVE，撞上任何一个正在读这张表的连接就会无限等——那正是
+    # 把单 worker 堵死的形状。等不到就抛、被这里吞掉，下次启动再补。
+        try:
+            from sqlalchemy import inspect as _sql_inspect, text as _sql_text
 
-        _cols = {c["name"] for c in _sql_inspect(engine).get_columns("generated_app_preview")}
-        if "shot_png_b64" not in _cols:
-            with engine.begin() as _conn:
-                _conn.execute(
+            _cols = {
+                c["name"]
+                for c in _sql_inspect(_init_conn).get_columns("generated_app_preview")
+            }
+            if "shot_png_b64" not in _cols:
+                _init_conn.execute(
                     _sql_text("alter table generated_app_preview add column shot_png_b64 text")
                 )
-            print("[app_store] generated_app_preview 补上 shot_png_b64 列")
-    except Exception as exc:  # noqa: BLE001 — 补不上就当没有这个来源
-        print(f"[app_store] 截图列补齐失败（回落 sheet 单来源）: {str(exc)[:160]}")
+                print("[app_store] generated_app_preview 补上 shot_png_b64 列")
+        except Exception as exc:  # noqa: BLE001 — 补不上就当没有这个来源
+            print(f"[app_store] 截图列补齐失败（回落 sheet 单来源）: {str(exc)[:160]}")
 
     class SqlAppStore(AppStoreBackend):
         def _row_from_record(self, record: dict[str, Any]) -> "GeneratedApp":
@@ -1164,7 +1290,7 @@ def get_backend() -> AppStoreBackend:
         db_url = (settings.APP_STORE_DATABASE_URL or "").strip()
         if db_url and db_url not in _failed_db_urls:
             try:
-                _backend_instance = _sqlalchemy_backend(db_url)
+                _backend_instance = _sqlalchemy_backend_within_budget(db_url)
             except Exception as exc:  # noqa: BLE001 — 连不上/驱动缺失时诚实降级
                 tcp_err = str(exc)[:200]
                 endpoint = neon_http_endpoint(db_url)

--- a/slide-rule-python/services/app_store.py
+++ b/slide-rule-python/services/app_store.py
@@ -1463,6 +1463,13 @@ def _attach_preview(
     if not b64:
         return
     try:
+        from .thumb_image import to_webp
+
+        # 参照板来自生图 API，是 PNG base64（实测 805~857KB）。同样只存派生图。
+        # 注意：这里压的**只是留给卡片显示的那一份**——设计 LLM 用的那张参照图
+        # 走的是内存里的原始 base64，不经过这里，画质不受影响。
+        raw = base64.b64decode(b64)
+        b64 = base64.b64encode(to_webp(raw)).decode("ascii")
         backend.save_preview(app_id, b64, source=PREVIEW_SOURCE_SHEET)
     except Exception as exc:  # noqa: BLE001 — 同上
         print(f"[app_store] 缩略图写入失败（不影响落库）: {str(exc)[:160]}")
@@ -1480,7 +1487,12 @@ def save_app_shot(app_id: str, png_bytes: bytes) -> bool:
     if not png_bytes:
         return False
     try:
-        b64 = base64.b64encode(png_bytes).decode("ascii")
+        from .thumb_image import to_webp
+
+        # 存派生图而不是原图（thumbor/imgproxy 的做法，理由见 thumb_image 头注）：
+        # 实测 805KB PNG → 43KB WebP，分辨率一个像素不减。fail-open——转不动就
+        # 原样存，卡片照常显示，只是没省下带宽。
+        b64 = base64.b64encode(to_webp(png_bytes)).decode("ascii")
         get_backend().save_preview(app_id, b64, source=PREVIEW_SOURCE_SHOT)
         return True
     except Exception as exc:  # noqa: BLE001 — 缩略图是增强项

--- a/slide-rule-python/services/app_store.py
+++ b/slide-rule-python/services/app_store.py
@@ -1253,12 +1253,42 @@ def _local_sqlite_backend() -> Optional[AppStoreBackend]:
         return None
 
 
+_PREFER_HTTP_ENV = "APP_STORE_NEON_HTTP"
+
+
+def prefer_neon_http() -> bool:
+    """是否**跳过 TCP、直接走 Neon SQL over HTTP**（2026-08-02 事故后加）。
+
+    ## 为什么需要一个显式开关
+
+    HTTP 这条通道本来只是兜底：TCP 初始化抛异常了才轮到它。但线上事故的形状恰恰
+    是 **TCP "能连上、只是慢得要死"**——探针过、连接最终也建得起来，于是永远走不
+    到 HTTP，哪怕在那台机器上 HTTP 明显更稳。
+
+    两条通道实测对比（同一个库、同一份数据）：
+
+      TCP    连接要在 pooler 解析出的 6 个地址里逐个试，每个 connect_timeout=4s，
+             最坏单次连接 24s；语句超时得靠 options 传，而连接串自带 options
+             （Neon 用它做端点路由）时传不进去。
+      HTTP   共享 httpx.Client（keep-alive），**每次查询 15s 硬超时**，
+             不存在"卡住不返回"。实测 p50 77ms（就是网络往返）、并发 8 吞吐
+             31 条/s，功能与 SQLAlchemy 后端逐项对齐（11 个接口方法全部自实现）。
+
+    默认不开，行为与之前逐字节一致。受这个坑的部署把它打开即可，不用改代码。
+    """
+    return (os.getenv(_PREFER_HTTP_ENV) or "").strip().lower() in ("1", "true", "yes", "on")
+
+
 def _current_signature() -> str:
     remote = (settings.APP_STORE_DATABASE_URL or "").strip()
     local = (getattr(settings, "APP_STORE_LOCAL_SQLITE", "") or "").strip()
     # 本地库配置也进签名：改了它（比如测试里置空）要能触发重建，否则会一直
     # 拿着上一次的后端单例，改配置像没生效。
-    return f"{remote}|{local}|jsonfile:{settings.APP_STORE_FILE}"
+    # 通道偏好同理——翻了开关要能重建。
+    return (
+        f"{remote}|{local}|jsonfile:{settings.APP_STORE_FILE}"
+        f"|http:{int(prefer_neon_http())}"
+    )
 
 
 def get_backend() -> AppStoreBackend:
@@ -1288,6 +1318,27 @@ def get_backend() -> AppStoreBackend:
         if _backend_instance is not None and _backend_signature == sig:
             return _backend_instance
         db_url = (settings.APP_STORE_DATABASE_URL or "").strip()
+        # 显式指定走 HTTP：跳过 TCP 那一整段（探针 + 多地址逐个试 + 建表补列），
+        # 直接用 SQL over HTTP。理由见 prefer_neon_http。
+        # 它自己失败了照旧往下降级，不会把人卡在这一级。
+        if db_url and db_url not in _failed_db_urls and prefer_neon_http():
+            endpoint = neon_http_endpoint(db_url)
+            if endpoint:
+                try:
+                    _backend_instance = NeonHttpAppStore(db_url, endpoint)
+                    print(f"[app_store] 按 {_PREFER_HTTP_ENV} 指定，直接走 Neon SQL over HTTP")
+                    _backend_signature = sig
+                    return _backend_instance
+                except Exception as exc:  # noqa: BLE001 — 指定了也可能连不上
+                    print(
+                        f"[app_store] 指定的 HTTP 通道不可用，继续按常规顺序降级: "
+                        f"{str(exc)[:200]}"
+                    )
+            else:
+                print(
+                    f"[app_store] 设了 {_PREFER_HTTP_ENV} 但连接串不是 Neon 主机，"
+                    f"忽略这个偏好"
+                )
         if db_url and db_url not in _failed_db_urls:
             try:
                 _backend_instance = _sqlalchemy_backend_within_budget(db_url)

--- a/slide-rule-python/services/thumb_image.py
+++ b/slide-rule-python/services/thumb_image.py
@@ -1,0 +1,136 @@
+"""缩略图编码（2026-08-02）——把卡片缩略图从 PNG 换成 WebP。
+
+## 为什么
+
+实测：一张卡片缩略图 **805~857KB PNG**，而卡片只有 309px 宽。应用中心一次首屏
+23 张卡 ≈ 10.7MB；在 5Mbps 出口上，**一个用户冷启动要 17 秒**，三个人同时进就是
+51 秒。而且越用越慢——每多一个应用就多 800KB。
+
+同样的像素换成 WebP（实测本仓库真实缩略图）：
+
+    1280x720  PNG  805KB  →  WebP q82  43KB   （小 19 倍，分辨率一个像素不减）
+    720x1280  PNG  857KB  →  WebP q82  60KB   （小 14 倍）
+
+## 三条做法都是抄成熟方案的，不是自己发明的
+
+① **存派生图，不存原图**（thumbor / imgproxy 的核心思路）。原图只在生成期当设计
+   参照用，用完即弃；库里留的那份只服务于卡片显示，那就该按显示需求存。
+   顺带把库也瘦了——原来每行约 1MB base64。
+
+② **按 Accept 头做格式协商**（thumbor / imgproxy / Next.js Image 都这么干）。
+   存 WebP，客户端声明认 WebP 就直接给；不认就现场转回 PNG。WebP 覆盖率已经
+   97%+，转码这条是给极老客户端和抓取工具留的，不是主路径。
+
+③ **只换格式、不降分辨率**。这是刻意的保守：降到卡片尺寸能到 20KB（再小一倍），
+   但那会引入"看着糊了"的风险，而 19 倍已经把带宽问题解决掉了。要再压的话，
+   应该等有人真觉得 43KB 还大的时候再说。
+
+## 质量取值
+
+q=82。参照：Next.js Image 默认 75、thumbor 默认 80、imgproxy 默认 80。取 82 是
+因为这些图是**界面截图**——大片纯色加细字，比照片更吃量化噪声，稍高一档更稳。
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+from typing import Optional
+
+#: WebP 质量。见模块头注的取值理由。
+WEBP_QUALITY = 82
+
+#: 各格式的魔数。库里存量是 PNG，新写入是 WebP，取图时要按实际内容报
+#: Content-Type——报错了浏览器可能拒绝渲染，也会让 CDN 缓存错类型。
+_MAGIC = (
+    (b"\x89PNG\r\n\x1a\n", "image/png"),
+    (b"\xff\xd8\xff", "image/jpeg"),
+)
+
+
+def sniff_media_type(data: bytes) -> str:
+    """按内容判断媒体类型；认不出按 PNG（历史存量就是 PNG）。
+
+    WebP 的魔数是 `RIFF....WEBP`——中间四字节是长度，所以不能整段前缀匹配。
+    """
+    if not data:
+        return "image/png"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    for magic, mime in _MAGIC:
+        if data.startswith(magic):
+            return mime
+    return "image/png"
+
+
+def _pillow() -> Optional[object]:
+    """惰性导入：没装 Pillow 时整条压缩链路静默失效、原样存 PNG，
+    不让一个"优化"变成新的失败面。"""
+    try:
+        from PIL import Image
+
+        return Image
+    except Exception:  # noqa: BLE001 — 没装/装坏都当"不可用"
+        return None
+
+
+def to_webp(data: bytes, *, quality: int = WEBP_QUALITY) -> bytes:
+    """把一张图转成 WebP。**分辨率不动**，只换编码。
+
+    fail-open 返回原始字节：转不动（Pillow 没装、格式不认、图损坏）时保持原样，
+    卡片照常显示，只是没省下带宽。缩略图是增强项，绝不能因为压缩失败就没图。
+
+    已经是 WebP 的直接返回——重复编码只会掉画质。
+    """
+    if not data:
+        return data
+    if sniff_media_type(data) == "image/webp":
+        return data
+    Image = _pillow()
+    if Image is None:
+        return data
+    try:
+        with Image.open(BytesIO(data)) as im:
+            # 截图里可能带 alpha（圆角/阴影）。WebP 支持 alpha，直接留着；
+            # 但调色板图（P 模式）要先转出来，否则 WebP 编码器会拒。
+            if im.mode in ("P", "LA"):
+                im = im.convert("RGBA")
+            elif im.mode not in ("RGB", "RGBA"):
+                im = im.convert("RGB")
+            buf = BytesIO()
+            im.save(buf, format="WEBP", quality=quality, method=4)
+            out = buf.getvalue()
+    except Exception:  # noqa: BLE001 — 见 docstring
+        return data
+    # 反常情况下 WebP 可能比原图还大（极小图/已高度压缩）。那就别换了。
+    return out if out and len(out) < len(data) else data
+
+
+def to_png(data: bytes) -> bytes:
+    """转回 PNG——只给不认 WebP 的客户端用（Accept 协商的兜底支）。
+
+    同样 fail-open：转不动就原样返回，让客户端自己决定怎么办。
+    """
+    if not data or sniff_media_type(data) == "image/png":
+        return data
+    Image = _pillow()
+    if Image is None:
+        return data
+    try:
+        with Image.open(BytesIO(data)) as im:
+            buf = BytesIO()
+            im.save(buf, format="PNG", optimize=True)
+            return buf.getvalue() or data
+    except Exception:  # noqa: BLE001
+        return data
+
+
+def client_accepts_webp(accept_header: Optional[str]) -> bool:
+    """客户端认不认 WebP。
+
+    缺 Accept 头时按**认**处理：那基本是脚本/抓取工具，给它更小的那份没坏处；
+    真不认的浏览器一定会明确列出自己能接的类型（`image/webp` 或 `*/*`）。
+    """
+    if not accept_header:
+        return True
+    lowered = accept_header.lower()
+    return "image/webp" in lowered or "*/*" in lowered

--- a/slide-rule-python/tests/test_app_store.py
+++ b/slide-rule-python/tests/test_app_store.py
@@ -493,3 +493,99 @@ def test_hung_init_thread_never_blocks_process_exit():
         release.set()
         store._sqlalchemy_backend = orig
         store._SQL_INIT_BUDGET_S = orig_budget
+
+
+# ────────────────────── 显式指定 Neon HTTP 通道 ──────────────────────
+#
+# 事故后加的口子：TCP "能连上、只是慢得要死"时，兜底逻辑永远轮不到 HTTP
+# （它只在 TCP 抛异常时才触发）。这一组盯这个开关的边界。
+
+
+def test_http_channel_is_opt_in(monkeypatch):
+    """默认不开——行为必须与加这个开关之前逐字节一致。"""
+    monkeypatch.delenv(store._PREFER_HTTP_ENV, raising=False)
+    assert store.prefer_neon_http() is False
+    for truthy in ("1", "true", "YES", "on"):
+        monkeypatch.setenv(store._PREFER_HTTP_ENV, truthy)
+        assert store.prefer_neon_http() is True, truthy
+    for falsy in ("0", "false", "no", ""):
+        monkeypatch.setenv(store._PREFER_HTTP_ENV, falsy)
+        assert store.prefer_neon_http() is False, falsy
+
+
+def test_http_preference_skips_the_tcp_path_entirely(monkeypatch, tmp_path):
+    """开了就**根本不碰 TCP**。
+
+    这是这个开关存在的全部意义：TCP 那一段（探针 + pooler 多地址逐个试 ×
+    connect_timeout 4s + 建表补列）正是把线上堵死的地方，指定 HTTP 就不该再
+    走进去一步。
+    """
+    tcp_calls = []
+    monkeypatch.setattr(
+        store, "_sqlalchemy_backend",
+        lambda url: tcp_calls.append(url) or (_ for _ in ()).throw(AssertionError("不该走 TCP")),
+    )
+    made = []
+
+    class FakeHttp:
+        def __init__(self, url, endpoint):
+            made.append(endpoint)
+
+    monkeypatch.setattr(store, "NeonHttpAppStore", FakeHttp)
+    monkeypatch.setenv(store._PREFER_HTTP_ENV, "1")
+    monkeypatch.setattr(
+        store.settings, "APP_STORE_DATABASE_URL",
+        "postgresql://u:p@ep-x-pooler.us-east-2.aws.neon.tech/db?sslmode=require",
+    )
+    store.reset_backend_cache()
+    try:
+        backend = store.get_backend()
+        assert isinstance(backend, FakeHttp), type(backend).__name__
+        assert made, "没有真的去建 HTTP 后端，用例空过"
+        assert tcp_calls == [], "开了 HTTP 偏好却仍然走了 TCP"
+    finally:
+        store.reset_backend_cache()
+
+
+def test_http_preference_still_degrades_when_http_is_down(monkeypatch, tmp_path):
+    """指定了 HTTP 也可能连不上——那时候要继续往下降级，不能把人卡在这一级。"""
+    class Broken:
+        def __init__(self, url, endpoint):
+            raise RuntimeError("http down")
+
+    monkeypatch.setattr(store, "NeonHttpAppStore", Broken)
+    monkeypatch.setattr(store, "_sqlalchemy_backend", lambda url: (_ for _ in ()).throw(OSError("tcp down")))
+    monkeypatch.setenv(store._PREFER_HTTP_ENV, "1")
+    monkeypatch.setattr(
+        store.settings, "APP_STORE_DATABASE_URL",
+        "postgresql://u:p@ep-x-pooler.us-east-2.aws.neon.tech/db?sslmode=require",
+    )
+    monkeypatch.setattr(store.settings, "APP_STORE_FILE", str(tmp_path / "apps.json"))
+    monkeypatch.setattr(store.settings, "APP_STORE_LOCAL_SQLITE", f"sqlite:///{tmp_path/'l.db'}")
+    store.reset_backend_cache()
+    try:
+        assert type(store.get_backend()).__name__ in ("SqlAppStore", "JsonFileAppStore")
+    finally:
+        store.reset_backend_cache()
+
+
+def test_http_preference_ignored_for_non_neon_hosts(monkeypatch, tmp_path):
+    """自建 PG / RDS 没有这个 HTTP 端点，盲目拼一个只会得到困惑的连接错误。
+    这种情况忽略偏好、照常走 TCP。"""
+    tcp = []
+    monkeypatch.setattr(
+        store, "_sqlalchemy_backend",
+        lambda url: tcp.append(url) or (_ for _ in ()).throw(OSError("tcp down")),
+    )
+    monkeypatch.setenv(store._PREFER_HTTP_ENV, "1")
+    monkeypatch.setattr(
+        store.settings, "APP_STORE_DATABASE_URL", "postgresql://u:p@pg.internal:5432/x"
+    )
+    monkeypatch.setattr(store.settings, "APP_STORE_FILE", str(tmp_path / "apps.json"))
+    monkeypatch.setattr(store.settings, "APP_STORE_LOCAL_SQLITE", f"sqlite:///{tmp_path/'l.db'}")
+    store.reset_backend_cache()
+    try:
+        store.get_backend()
+        assert tcp, "非 Neon 主机应当照常走 TCP"
+    finally:
+        store.reset_backend_cache()

--- a/slide-rule-python/tests/test_app_store.py
+++ b/slide-rule-python/tests/test_app_store.py
@@ -347,3 +347,149 @@ def test_neon_error_fields_cover_official_driver_list():
     }
     assert official <= set(store._NEON_ERROR_FIELDS)
     assert "neon:retryable" in store._NEON_ERROR_FIELDS
+
+
+# ────────────────────── Neon 事故（2026-08-02）的三层守卫 ──────────────────────
+#
+# 事故形状：切回 Neon 后 Python 单 worker 被堵死，/api/health 一起超时。
+# 三个原因叠加，各配一条守卫：
+#   ① fail-open 只兜异常、不兜"卡住"        → 服务端超时 + 墙钟预算
+#   ② 初始化每一步各开一条连接              → 合并成一次握手
+#   ③ async 路由里同步调库，单 worker       → to_thread（在路由那侧断言）
+
+
+def test_postgres_config_sets_server_side_timeouts():
+    """**没有语句级超时 = 那套四级 fail-open 是摆设。**
+
+    降级全靠 except 触发，而一条永远不返回的查询什么都不抛。connect_timeout
+    只管握手，连上之后想跑多久跑多久——线上就是这么被堵死的。
+    """
+    connect_args, _ = store._sql_engine_config(
+        "postgresql+psycopg://u:p@ep-x-pooler.neon.tech/db?sslmode=require", _FakeNullPool
+    )
+    opts = connect_args.get("options") or ""
+    assert f"statement_timeout={store._PG_STATEMENT_TIMEOUT_MS}" in opts
+    # 等锁超时是给 DDL 的：ALTER TABLE 要 ACCESS EXCLUSIVE，撞上任何一个正在读
+    # 这张表的连接就会无限等，那正是把单 worker 堵死的形状。
+    assert f"lock_timeout={store._PG_LOCK_TIMEOUT_MS}" in opts
+    assert f"idle_in_transaction_session_timeout={store._PG_IDLE_TX_TIMEOUT_MS}" in opts
+
+
+def test_connection_string_options_are_never_clobbered():
+    """连接串自带 options 时不许覆盖——Neon 用 `options=endpoint%3D...` 做端点
+    路由，盖掉就连错库了。宁可这一条没有服务端超时（还有墙钟预算兜底），也不能
+    改坏路由。"""
+    connect_args, _ = store._sql_engine_config(
+        "postgresql+psycopg://u:p@ep-x.neon.tech/db?options=endpoint%3Dep-x", _FakeNullPool
+    )
+    assert "options" not in connect_args
+
+
+def test_sqlite_gets_no_postgres_timeouts():
+    """SQLite 不认 postgres 的 options，塞进去会连不上。"""
+    connect_args, _ = store._sql_engine_config("sqlite:///x.db", _FakeNullPool)
+    assert "options" not in connect_args
+
+
+def test_slow_remote_init_degrades_instead_of_hanging(tmp_path, monkeypatch):
+    """**初始化卡住时必须降级，不能吊死。**
+
+    这是事故的核心：存储层承诺"绝不拖垮主链路"，但那个承诺只覆盖了"失败"，
+    没覆盖"不返回"。这条用例模拟一个永远不返回的初始化，断言 get_backend 在
+    预算内放弃并落到本地 SQLite——而不是一直等下去。
+    """
+    started = __import__("threading").Event()
+    real_factory = store._sqlalchemy_backend
+
+    # **只拦远端那一个 URL**：_local_sqlite_backend 走的是同一个工厂函数，
+    # 一刀切地替换会让降级目标也卡住——本地兜底那一步没有预算保护，于是整条
+    # 用例挂死。第一版就是这么写的，被自己挂住了。
+    def blocks_only_the_remote(url):
+        if "invalid.internal" in url:
+            started.set()
+            __import__("threading").Event().wait()  # 永远不返回
+        return real_factory(url)
+
+    monkeypatch.setattr(store, "_sqlalchemy_backend", blocks_only_the_remote)
+    monkeypatch.setattr(store, "_SQL_INIT_BUDGET_S", 0.5)
+    # 刻意用**非 Neon** 主机：*.neon.tech 会让降级链先去试 SQL-over-HTTP，
+    # 那是一次真实网络请求，会把这条用例的耗时变成网络超时而不是预算。
+    monkeypatch.setattr(
+        store.settings, "APP_STORE_DATABASE_URL",
+        "postgresql://u:p@db.invalid.internal:5432/x?sslmode=require",
+    )
+    monkeypatch.setattr(store.settings, "APP_STORE_FILE", str(tmp_path / "apps.json"))
+    monkeypatch.setattr(
+        store.settings, "APP_STORE_LOCAL_SQLITE", f"sqlite:///{tmp_path / 'local.db'}"
+    )
+    store.reset_backend_cache()
+
+    import time as _t
+
+    t0 = _t.time()
+    backend = store.get_backend()
+    elapsed = _t.time() - t0
+
+    assert started.is_set(), "初始化根本没被调用，这条用例是空过的"
+    assert elapsed < 5, f"没有在预算内放弃，等了 {elapsed:.1f}s"
+    assert type(backend).__name__ == "SqlAppStore", "应当降级到本地 SQLite"
+    store.reset_backend_cache()
+
+
+def test_remote_init_opens_one_connection_not_three(monkeypatch):
+    """建表 + 查列 + 补列**共用一条连接**。
+
+    NullPool 下每次 engine 级操作都是新建连接。平时无所谓，但线上撞到的正是
+    "每次连接都慢"（Neon pooler 多地址 × connect_timeout=4s），连接次数在这条
+    路径上是直接乘上去的成本。这条按源码钉住，因为真连库测不了。
+    """
+    import inspect as _inspect
+
+    src = _inspect.getsource(store._sqlalchemy_backend)
+    body = src[src.index("engine = create_engine"):src.index("class SqlAppStore")]
+    # 只允许出现一次 engine 级的连接获取
+    assert body.count("engine.begin()") == 1, "初始化里不止一次 engine.begin()"
+    assert "create_all(_init_conn)" in body, "create_all 没有复用那条连接"
+    assert "_sql_inspect(_init_conn)" in body, "查列没有复用那条连接"
+    assert "_sql_inspect(engine)" not in body, "查列又开了一条新连接"
+
+
+def test_hung_init_thread_never_blocks_process_exit():
+    """**卡住的初始化线程必须是 daemon。**
+
+    第一版用 ThreadPoolExecutor + future.result(timeout=…)，被这条抓了：它的
+    工作线程是非守护线程，而 concurrent.futures 注册了 atexit 钩子去 join 它们
+    ——卡住的线程会挡住**进程退出**。那等于把"启动卡死"换成"关停卡死"，容器停
+    不下来，部署时更难受。
+
+    这条不是风格检查：非 daemon 会让整个测试进程在收集完后挂死（实测撞到过）。
+    """
+    import threading
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocks(_url):
+        started.set()
+        release.wait(timeout=30)
+        raise RuntimeError("late")
+
+    orig = store._sqlalchemy_backend
+    orig_budget = store._SQL_INIT_BUDGET_S
+    store._sqlalchemy_backend = blocks
+    store._SQL_INIT_BUDGET_S = 0.3
+    try:
+        try:
+            store._sqlalchemy_backend_within_budget("postgresql://u:p@h/db")
+        except TimeoutError:
+            pass
+        else:
+            raise AssertionError("超预算时应当抛 TimeoutError")
+        assert started.is_set(), "初始化没被调用，用例空过"
+        stuck = [t for t in threading.enumerate() if t.name == "appstore-init"]
+        assert stuck, "没找到那个卡住的线程，用例空过"
+        assert all(t.daemon for t in stuck), "初始化线程不是 daemon，会挡住进程退出"
+    finally:
+        release.set()
+        store._sqlalchemy_backend = orig
+        store._SQL_INIT_BUDGET_S = orig_budget

--- a/slide-rule-python/tests/test_event_loop_not_blocked.py
+++ b/slide-rule-python/tests/test_event_loop_not_blocked.py
@@ -1,0 +1,94 @@
+"""推演跑起来时，服务其余部分必须照常响应（2026-08-02 线上事故）。
+
+事故形状：只要有人在生成应用，整个服务就不响应，连 /api/health 都超时；而且
+想停都停不干净（dev:stop 停不掉、端口一直被占）。
+
+根因不在数据库——本地复现时走的是 Neon HTTP 通道，实测 p50 77ms。真正的原因是
+`drive_full_v5_session` 是**同步**函数（一趟 6~20 分钟），却被直接写在
+`async def` 路由里，于是整段跑在事件循环那条线程上。单 worker 下，事件循环被
+占住 = 全站失联。
+
+修法是 FastAPI 官方口径：路由声明成 `def`，Starlette 会自动 run_in_threadpool。
+这份测试盯的就是这条纪律不被改回去。
+"""
+
+import inspect
+import threading
+import time
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from routes import sliderule_full
+
+
+BLOCKING_ROUTES = ["drive", "drive_full"]
+
+
+@pytest.mark.parametrize("name", BLOCKING_ROUTES)
+def test_blocking_routes_are_declared_sync(name):
+    """**这两条路由必须是 `def`，不能是 `async def`。**
+
+    它们内部调的是同步的重活（drive_reasoning_turn / drive_full_v5_session）。
+    写成 async 就等于把 6~20 分钟的阻塞放进事件循环——这正是线上那次全站失联。
+
+    为什么钉签名而不是钉"有没有 to_thread"：签名是声明式的，漏不掉；手动包
+    to_thread 要在每个调用点各写一遍，而这两条当初正是漏掉的那两条。
+    """
+    fn = getattr(sliderule_full, name)
+    assert not inspect.iscoroutinefunction(fn), (
+        f"{name} 又变回 async def 了——同步重活会占住事件循环，见本文件头注"
+    )
+
+
+def test_health_still_answers_while_a_long_drive_is_running(monkeypatch):
+    """**跑着推演的时候，健康检查必须照常答。**
+
+    这条是行为级的复现：让 drive-full 卡住不返回，同时打 /api/health，断言它
+    在秒级内拿到响应。改回 async def 时这条会挂——事件循环被占住，健康检查
+    根本轮不到。
+    """
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_drive(state, max_loops=10, user_instruction=""):
+        started.set()
+        release.wait(timeout=30)   # 模拟一趟长推演
+        return state
+
+    monkeypatch.setattr(sliderule_full, "drive_full_v5_session", blocking_drive, raising=False)
+
+    app = FastAPI()
+    app.include_router(sliderule_full.router, prefix="/api/sliderule")
+
+    @app.get("/api/health")
+    def health():
+        return {"ok": True}
+
+    with TestClient(app) as client:
+        sid = client.post("/api/sliderule/sessions", json={"goal": {"text": "阻塞测试"}})
+        assert sid.status_code == 200, sid.text
+        state = sid.json()["state"]
+
+        def fire():
+            try:
+                client.post("/api/sliderule/drive-full",
+                            json={"state": state, "userText": "阻塞测试", "max_loops": 1})
+            except Exception:
+                pass
+
+        worker = threading.Thread(target=fire, daemon=True)
+        worker.start()
+        try:
+            assert started.wait(timeout=15), "推演没跑起来，这条用例是空过的"
+            t0 = time.time()
+            res = client.get("/api/health")
+            elapsed = time.time() - t0
+            assert res.status_code == 200
+            assert elapsed < 5, (
+                f"推演进行中健康检查花了 {elapsed:.1f}s——事件循环被占住了"
+            )
+        finally:
+            release.set()
+            worker.join(timeout=15)

--- a/slide-rule-python/tests/test_thumb_image.py
+++ b/slide-rule-python/tests/test_thumb_image.py
@@ -1,0 +1,196 @@
+"""缩略图编码（PNG → WebP）的覆盖。
+
+背景：实测一张卡片缩略图 805~857KB PNG，而卡片只有 309px 宽。应用中心一次首屏
+23 张卡 ≈ 10.7MB，5Mbps 出口上一个用户冷启动 17 秒、三个人 51 秒。同样像素换成
+WebP 是 43~60KB。
+
+这份测试盯三件事：
+  ① 真的变小了，而且**分辨率一个像素不减**（只换格式是刻意的保守取舍）；
+  ② 每一步都 fail-open——压缩是增强项，绝不能因为它失败就没图；
+  ③ 取图时按内容报类型 + Accept 协商，历史存量的 PNG 照常能取。
+"""
+
+from io import BytesIO
+
+import pytest
+
+from services.thumb_image import (
+    WEBP_QUALITY,
+    client_accepts_webp,
+    sniff_media_type,
+    to_png,
+    to_webp,
+)
+
+PIL = pytest.importorskip("PIL", reason="没装 Pillow 时压缩链路本就静默失效")
+
+
+def _screenshot_png(w: int = 1280, h: int = 720) -> bytes:
+    """造一张**像界面截图**的图：大片纯色 + 细线 + 文字块。
+
+    不用随机噪声——噪声图 PNG 压不动、WebP 也压不动，测出来的比例毫无意义，
+    正好把这次改动的收益整个抹平。
+    """
+    from PIL import Image, ImageDraw
+
+    im = Image.new("RGB", (w, h), (247, 248, 250))
+    d = ImageDraw.Draw(im)
+    d.rectangle([0, 0, w, 56], fill=(255, 255, 255))
+    d.rectangle([0, 56, 220, h], fill=(32, 41, 55))
+    for i in range(6):
+        x = 250 + i * 160
+        d.rectangle([x, 90, x + 140, 200], fill=(255, 255, 255), outline=(226, 232, 240))
+        d.text((x + 12, 120), "12,480", fill=(15, 23, 42))
+    for row in range(14):
+        y = 240 + row * 32
+        d.line([250, y, w - 30, y], fill=(233, 236, 240))
+        d.text((260, y - 14), "CM-2026-5993   已完成", fill=(71, 85, 105))
+    buf = BytesIO()
+    im.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+# ────────────────────── ① 真的变小，且分辨率不减 ──────────────────────
+
+
+def test_webp_conversion_preserves_resolution():
+    """转换后**分辨率一个像素不减**——这是这次改动最重要的约束。
+
+    只换格式、不降分辨率是刻意的保守：降到卡片尺寸能再小一半，但会引入"看着
+    糊了"的风险，而只换格式已经把带宽问题解决掉了。
+
+    ⚠️ 这里**不断言压缩比**。合成夹具造不出真实缩略图那种体积（本文件的夹具
+    才几 KB，真实缩略图 805~857KB），在它上面断言比例是自欺欺人——真实收益
+    是在生产图上量的：
+
+        1280x720  PNG 805KB → WebP  43KB   （19 倍）
+        1280x720  PNG 808KB → WebP  39KB   （20 倍）
+         720x1280 PNG 857KB → WebP  60KB   （14 倍）
+
+    压缩比是内容的经验性质，靠 scripts/thumb_recompress.py 的实跑输出复核，
+    不靠单测假装。
+    """
+    from PIL import Image
+
+    png = _screenshot_png()
+    webp = to_webp(png)
+
+    assert sniff_media_type(webp) == "image/webp"
+    with Image.open(BytesIO(png)) as a, Image.open(BytesIO(webp)) as b:
+        assert a.size == b.size, f"分辨率被改了：{a.size} → {b.size}"
+
+
+def test_already_webp_is_returned_untouched():
+    """已经是 WebP 的直接返回——重复编码只会掉画质。
+
+    这条真会被走到：采集端出的就是 WebP（thumb-capture.ts），而写入路径仍然会
+    调 to_webp（那是给参照板和历史存量用的）。
+    """
+    webp = to_webp(_screenshot_png())
+    assert to_webp(webp) is webp
+
+
+# ────────────────────── ② 每一步都 fail-open ──────────────────────
+
+
+def test_garbage_bytes_pass_through_unchanged():
+    """不是图片 → 原样返回，不抛。
+
+    缩略图是增强项：压不动的正确表现是"没省下带宽"，不是"这张卡没图了"。
+    """
+    junk = b"this is definitely not an image" * 4
+    assert to_webp(junk) == junk
+    assert to_png(junk) == junk
+
+
+def test_empty_input_is_safe():
+    assert to_webp(b"") == b""
+    assert to_png(b"") == b""
+
+
+def test_missing_pillow_degrades_silently(monkeypatch):
+    """没装 Pillow 时整条链路静默失效、原样存 PNG。
+
+    requirements 里加了 pillow，但部署环境可能装不上（编译失败/精简镜像）。
+    那时候功能必须照常，只是不省带宽。
+    """
+    import services.thumb_image as ti
+
+    monkeypatch.setattr(ti, "_pillow", lambda: None)
+    png = _screenshot_png()
+    assert ti.to_webp(png) == png
+    assert ti.to_png(png) == png
+
+
+def test_webp_is_skipped_when_it_would_be_bigger():
+    """反常情况下 WebP 可能比原图还大（极小图）。那就别换了。"""
+    from PIL import Image
+
+    buf = BytesIO()
+    Image.new("RGB", (2, 2), (255, 255, 255)).save(buf, format="PNG")
+    tiny = buf.getvalue()
+    out = to_webp(tiny)
+    assert len(out) <= len(tiny)
+
+
+# ────────────────────── ③ 类型嗅探与 Accept 协商 ──────────────────────
+
+
+def test_sniff_recognizes_both_stored_formats():
+    """库里存量是 PNG、新写入是 WebP，取图时得按**内容**报类型。
+
+    报错类型浏览器可能拒绝渲染，CDN 也会缓存错。
+    """
+    png = _screenshot_png()
+    assert sniff_media_type(png) == "image/png"
+    assert sniff_media_type(to_webp(png)) == "image/webp"
+
+
+def test_sniff_falls_back_to_png_for_unknown():
+    """认不出按 PNG——历史存量就是 PNG，这个兜底是给它们的。
+
+    ⚠️ 正因为有这个兜底，sniff **不能**单独用来做上传入口校验
+    （那会让任意字节流被判成 PNG 放进来）。入口另有一道真魔数检查。
+    """
+    assert sniff_media_type(b"\x00\x01\x02\x03") == "image/png"
+
+
+def test_webp_can_be_converted_back_for_old_clients():
+    """不认 WebP 的客户端要能拿到 PNG（Accept 协商的兜底支）。"""
+    from PIL import Image
+
+    png = _screenshot_png()
+    back = to_png(to_webp(png))
+    assert sniff_media_type(back) == "image/png"
+    with Image.open(BytesIO(back)) as im:
+        assert im.size == (1280, 720)
+
+
+@pytest.mark.parametrize(
+    "accept,expected",
+    [
+        ("image/avif,image/webp,image/apng,*/*", True),
+        ("image/webp", True),
+        ("*/*", True),
+        (None, True),        # 缺 Accept 基本是脚本/抓取工具，给小的没坏处
+        ("", True),
+        ("image/png", False),
+        ("text/html", False),
+    ],
+)
+def test_accept_negotiation(accept, expected):
+    assert client_accepts_webp(accept) is expected
+
+
+def test_quality_matches_the_frontend_constant():
+    """服务端与采集端的质量必须一致，否则同一张卡两条来源画质不一样。
+
+    采集端在 client/src/lib/thumb-capture.ts 里是 0~1 的小数。
+    """
+    from pathlib import Path
+
+    src = Path(__file__).resolve().parents[2] / "client/src/lib/thumb-capture.ts"
+    text = src.read_text(encoding="utf-8")
+    assert f"const WEBP_QUALITY = {WEBP_QUALITY / 100}" in text, (
+        f"前端质量常量与服务端 {WEBP_QUALITY} 对不上"
+    )


### PR DESCRIPTION
上一批（PR #18）已经合过，这次只有之后的 4 个提交。全部来自同一次线上事故的
排查——现象是「切回 Neon 后 Python 单 worker 被堵死，/api/health 一起超时」，
但查下来根因有三层，且**都不是 Neon 的问题**。

## 一、Neon 初始化会堵死（cc4834046）

先量了一遍「是库慢还是代码慢」：库不慢。`select 1` 70ms、`count(*)` 26 行表
71ms（比纯往返只多 1ms）、列表查询 102ms——那 70ms 全是网络往返，查询执行几乎
不花时间。

贵的是**建立连接**：Neon pooler 解析出 6 个地址（3 IPv4 + 3 IPv6），psycopg
逐个试、每个 connect_timeout=4s → 单次连接最坏 24s。而探针只探第一个 IPv4，
探过了不代表真连接走同一条路——「Neon 能通」和「服务卡死」因此可以同时成立。

三层修复：
- **服务端超时**进 connect_args：statement_timeout 8s / lock_timeout 3s /
  idle_in_transaction 10s。原来只有 connect_timeout，连上之后想跑多久跑多久，
  而那套四级 fail-open 全靠 except 触发——**卡住不抛异常，于是一级都不会降**。
  连接串自带 options 时不覆盖（Neon 用它做端点路由）。
- **初始化墙钟预算 12s**，唯一不依赖库配合的一道。超了就降级到下一级存储。
- **初始化连接数 3 → 1**：建表 + 查列 + 补列合并成一次握手。NullPool 下每次
  都是新建连接，而连接次数在这条路径上是直接乘成本的（最坏 72s → 24s）。

写这个修复时被自己的测试抓到一次：墙钟预算第一版用 ThreadPoolExecutor，它的
工作线程是非守护线程，concurrent.futures 的 atexit 钩子会 join 它们——卡住的
线程会挡住**进程退出**，等于把「启动卡死」换成「关停卡死」。改用 daemon 线程。

## 二、可以显式指定走 HTTP 通道（02df2020c）

上一条修完还漏了个口子：**HTTP 通道只能当兜底**，触发条件是 TCP 抛异常。而
事故形状恰恰是 TCP「能连上、只是慢得要死」，于是永远轮不到 HTTP。

新增 `APP_STORE_NEON_HTTP`（默认关，行为逐字节不变）。开了就跳过 TCP 那一整段，
直接走 SQL over HTTP。

选它的依据是实测过的，不是拍脑袋：
- **能力**：AppStoreBackend 11 个接口方法，HTTP 后端全部自己实现。
- **功能对拍**（真实生产库、临时记录跑完删干净）：写入读回 / 版本链 / 参照板
  继承 / 截图写读 / 删除连缩略图一起清——全对，类型也没丢。
- **性能**：p50 77ms、并发 8 吞吐 31 条/s、应用中心首屏 606ms（还是跨区）。
- **健壮性**：共享 httpx.Client + **每次查询 15s 硬超时**，它不可能卡住不返回。

非 Neon 主机忽略这个偏好；HTTP 自己连不上照旧继续降级到 SQLite/JSON。

## 三、推演跑起来时整站失联（e199e4479）

上面两条修完，本地又复现了一次同样的症状——而这次根本没碰数据库（走 HTTP
通道，70ms）。真正更普遍的原因在这里：

    async def drive_full(...):
        new_state = drive_full_v5_session(...)   # 同步函数，没 await 也没 to_thread

drive_full_v5_session 是**同步**的，一趟推演 6~20 分钟（实测 374~1190s），却跑
在事件循环那条线程上。uvicorn 单 worker → 事件循环被占住 = 全站失联。前端走的
确实是这条同步路由（sliderule-marathon-driver.ts）。

修法用的是 FastAPI 官方口径：**路由声明成 `def` 而不是 `async def`**，Starlette
会自动 run_in_threadpool（底层 anyio.to_thread.run_sync）。两条路由函数体里一个
await 都没有，去掉 async 是无损的。比手动包 to_thread 好在**签名是声明式的，
漏不掉**——这两条当初正是漏掉的那两条。

代价写进注释：线程池默认 40 个槽，每趟推演占一个槽十几分钟。真到并发 40 那天，
正解是把推演挪进任务队列，而不是把这个数字调大。

顺带把「关不掉」也修了：Dockerfile 补 `--timeout-graceful-shutdown`（默认 30s）。
uvicorn 收到 SIGTERM 后默认**无限等**在途请求，一趟推演十几分钟——容器就停不
下来（本地实测 dev:stop 停不掉、端口一直被占，部署时表现为滚动更新卡住）。

## 四、缩略图 PNG → WebP（f687c2aaa）

顺着容量问题量出来的：瓶颈不是 CPU 内存，是带宽，而且是自找的——卡片只有
309px 宽，却在传 1280×720 的 PNG，**每张 805~857KB**。

三条做法抄的是 thumbor / imgproxy / Next.js Image 的共同思路（**没有引入这些
服务本身**，只多一个 Pillow）：
- 存派生图不存原图（原图只在生成期当设计参照，用完即弃）
- 按 Accept 头做格式协商（不认 WebP 的现场转回 PNG）
- **只换格式、不降分辨率**——降到卡片尺寸能再小一倍，但会引入「看着糊了」的
  风险，而只换格式已经解决问题了

实测存量 12 张回填：**6.3MB → 0.8MB（小 8.2 倍）**，5Mbps 上冷启动 10.0s →
1.2s。参照板 15~19 倍、真截图 5~8 倍。容量从「1~2 人同时用」变成「20 人以上」，
且不再越用越慢。

每一步 fail-open：没装 Pillow / 格式不认 / 图损坏，一律原样返回——绝不让一个
「优化」变成新的失败面。

## 需要注意的

- **必须重建镜像**：requirements 加了 pillow，Dockerfile 改了启动命令。只 pull
  代码不重建，这两条不会生效。
- 想恢复 Neon 画廊数据：重建部署后加 `APP_STORE_NEON_HTTP=true`，连接串换回
  Neon。
- 存量缩略图回填脚本 scripts/thumb_recompress.py 已在生产库跑过（--apply），
  不用再跑。默认只看不写。

## 验证

- Python 全量 **2219 passed / 7 skipped**，tsc 干净，前端缩略图相关 23 passed。
- 新增断言逐条反向验证：去掉服务端超时 → 红；**去掉墙钟预算 → 用例直接死等被
  kill**（正是线上那个形状）；初始化拆回多条连接 → 红；初始化线程改回非
  daemon → 红；路由改回 async def → 签名那条立刻红、行为那条**卡 30 秒才失败**。
- 端到端：取图返回 image/webp + immutable，带 `Accept: image/png` 时如实转回
  PNG 且分辨率仍是 1280×720；真实浏览器里 12 张图全部 WebP、0 张渲染失败、
  首屏合计 780KB。

## 一处被自己推翻的测试

缩略图那条原本断言「压缩比 > 5 倍」，用合成夹具跑出来只有 2.7 倍就红了。查下来
是**测法不成立**——合成夹具才几 KB，造不出真实缩略图那种体积。改成只钉契约
（格式变了、分辨率一个像素没变、fail-open），压缩比交给回填脚本的实跑输出复核。